### PR TITLE
Fix SQL provisioning script

### DIFF
--- a/provision/Init.ps1
+++ b/provision/Init.ps1
@@ -17,7 +17,29 @@ function Load-Module
   $Ignore = Import-Module -Name $QualifiedModuleName -PassThru -Verbose:$False -EA Stop
 }
 
+function Check-Azure-Version
+{
+    Param ([version]$requiredVersion)
+
+    if (-Not (Get-Module -ListAvailable -Name Azure)) {
+        Throw "Azure Powershell SDK is not installed." 
+    }
+
+    if (-Not (Get-Module Azure)) {
+        Import-Module Azure
+    }
+
+    $version = (Get-Module Azure).Version
+    Write-Host "Azure Powershell SDK Version $($version) is installed."
+
+    if ($version -lt $requiredVersion) {
+        Throw "This script requires at least version $($requiredVersion) of the Azure Powershell SDK."
+    }
+}
+
 ##
 # script initialization
 ##
+Check-Azure-Version "0.9.3"
+
 Load-Module -ModuleName AzureUtilities -ModuleLocation .\Modules

--- a/provision/Provision-SQLDatabase.ps1
+++ b/provision/Provision-SQLDatabase.ps1
@@ -60,7 +60,7 @@ Using-AzureResourceManagerMode ({
         $secPassword = ConvertTo-SecureString $ServerAdminPassword -AsPlainText -Force
         $credentials = New-Object System.Management.Automation.PSCredential($ServerAdminLogin, $secPassword)
 
-        $serverContext = New-AzureSqlServer -ResourceGroupName $ResourceGroupName -ServerName $ServerName -SqlAdminCredentials $credentials -location $Location
+        $serverContext = New-AzureSqlServer -ResourceGroupName $ResourceGroupName -ServerName $ServerName -SqlAdministratorCredentials $credentials -location $Location
     
         Write-Verbose ("Created server: {0}" -f $serverContext.ServerName)
     }


### PR DESCRIPTION
I was trying out the latest of the provisioning scripts and found that:
1. It needed a newer Azure Powershell SDK to get the `New-AzureSqlServer` cmdlet, so I downloaded the latest (June 2015).
2. After installing that, it choked on the `-SqlAdminCredentials` parameter.

The [MSDN for that command](https://msdn.microsoft.com/en-us/library/mt163526.aspx) shows the `-SqlAdminCredentials` parameter, but apparently it was renamed [in this commit](https://github.com/Azure/azure-powershell/commit/94ed44dfb24f3e50e8e7e7f606d0c549941a00d9#diff-5d9fa0d07f62f8dd0e4352423c264dc0L155) to `-SqlAdministratorCredentials`.
