### PR TITLE
Improve simulator Async usage

### DIFF
--- a/src/Implementation/Shared/Core/AsyncPump.cs
+++ b/src/Implementation/Shared/Core/AsyncPump.cs
@@ -1,0 +1,97 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Microsoft.Practices.IoTJourney
+{
+    /// <summary>
+    /// Provides a pump that supports running asynchronous methods on the current thread.
+    /// This is useful for creating an async context in a console application.
+    /// </summary>
+    /// <remarks>
+    /// See http://blogs.msdn.com/b/pfxteam/archive/2012/01/20/10259049.aspx
+    /// </remarks>
+    public static class AsyncPump
+    {
+        /// <summary>
+        /// Runs the specified asynchronous function.
+        /// </summary>
+        /// <param name="func">The asynchronous function to execute.</param>
+        public static void Run(Func<Task> func)
+        {
+            if (func == null) throw new ArgumentNullException("func");
+
+            var prevCtx = SynchronizationContext.Current;
+            try
+            {
+                // Establish the new context
+                var syncCtx = new SingleThreadSynchronizationContext();
+                SynchronizationContext.SetSynchronizationContext(syncCtx);
+
+                // Invoke the function and alert the context to when it completes
+                var t = func();
+                if (t == null) throw new InvalidOperationException("No task provided.");
+                t.ContinueWith(delegate { syncCtx.Complete(); }, TaskScheduler.Default);
+
+                // Pump continuations and propagate any exceptions
+                syncCtx.RunOnCurrentThread();
+                t.GetAwaiter().GetResult();
+            }
+            finally
+            {
+                SynchronizationContext.SetSynchronizationContext(prevCtx);
+            }
+        }
+
+        /// <summary>
+        /// Provides a SynchronizationContext that's single-threaded.
+        /// </summary>
+        private sealed class SingleThreadSynchronizationContext : SynchronizationContext
+        {
+            /// <summary>
+            /// The queue of work items.
+            /// </summary>
+            private readonly BlockingCollection<KeyValuePair<SendOrPostCallback, object>> _queue =
+                new BlockingCollection<KeyValuePair<SendOrPostCallback, object>>();
+
+            /// <summary>
+            /// Dispatches an asynchronous message to the synchronization context.
+            /// </summary>
+            /// <param name="d">The System.Threading.SendOrPostCallback delegate to call.</param>
+            /// <param name="state">The object passed to the delegate.</param>
+            public override void Post(SendOrPostCallback d, object state)
+            {
+                if (d == null) throw new ArgumentNullException("d");
+
+                _queue.Add(new KeyValuePair<SendOrPostCallback, object>(d, state));
+            }
+
+            /// <summary>
+            /// Not supported.
+            /// </summary>
+            public override void Send(SendOrPostCallback d, object state)
+            {
+                throw new NotSupportedException("Synchronously sending is not supported.");
+            }
+
+            /// <summary>
+            /// Runs an loop to process all queued work items.
+            /// </summary>
+            public void RunOnCurrentThread()
+            {
+                foreach (var workItem in _queue.GetConsumingEnumerable())
+                    workItem.Key(workItem.Value);
+            }
+
+            /// <summary>
+            /// Notifies the context that no more work will arrive.
+            /// </summary>
+            public void Complete() { _queue.CompleteAdding(); }
+        }
+    }
+}

--- a/src/Implementation/Shared/Core/Core.csproj
+++ b/src/Implementation/Shared/Core/Core.csproj
@@ -87,6 +87,7 @@
     <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="AsyncPump.cs" />
     <Compile Include="ConfigurationHelper.cs" />
     <Compile Include="Guard.cs" />
     <Compile Include="Logging\ScenarioSimulatorEventSource.cs" />

--- a/src/RunFromConsole/ColdStorage.ConsoleHost/Program.cs
+++ b/src/RunFromConsole/ColdStorage.ConsoleHost/Program.cs
@@ -26,7 +26,7 @@ namespace Microsoft.Practices.IoTJourney.ColdStorage.ConsoleHost
 
             observableEventListener.LogToConsole();
 
-            Tests.Common.ConsoleHost.WithOptions(new Dictionary<string, Func<CancellationToken, Task>>
+            Tests.Common.ConsoleHost.RunWithOptionsAsync(new Dictionary<string, Func<CancellationToken, Task>>
             {
                 { "Provision Resources", ProvisionResourcesAsync },
                 { "Run Cold Storage Consumer", RunAsync }

--- a/src/RunFromConsole/ScenarioSimulator.ConsoleHost/Program.cs
+++ b/src/RunFromConsole/ScenarioSimulator.ConsoleHost/Program.cs
@@ -18,6 +18,11 @@ namespace Microsoft.Practices.IoTJourney.ScenarioSimulator.ConsoleHost
 
         private static void Main(string[] args)
         {
+            AsyncPump.Run(() => MainAsync(args));
+        }
+
+        private static async Task MainAsync(string[] args)
+        {
             var observableEventListener = new ObservableEventListener();
 
             observableEventListener.EnableEvents(
@@ -40,7 +45,7 @@ namespace Microsoft.Practices.IoTJourney.ScenarioSimulator.ConsoleHost
                     ? GetWebJobCancellationToken()
                     : CancellationToken.None;
 
-                deviceSimulator.RunSimulationAsync(scenario, ct).Wait(); // todo, use await after #138 is merged
+                await deviceSimulator.RunSimulationAsync(scenario, ct);
                 return;
             }
 
@@ -51,7 +56,7 @@ namespace Microsoft.Practices.IoTJourney.ScenarioSimulator.ConsoleHost
                     scenario => "Run " + scenario,
                     scenario => (Func<CancellationToken, Task>)(token => deviceSimulator.RunSimulationAsync(scenario, token)));
 
-            Tests.Common.ConsoleHost.WithOptions(options);
+            await Tests.Common.ConsoleHost.RunWithOptionsAsync(options);
         }
         
         private static CancellationToken GetWebJobCancellationToken()

--- a/src/RunFromConsole/WarmStorage.ConsoleHost/Program.cs
+++ b/src/RunFromConsole/WarmStorage.ConsoleHost/Program.cs
@@ -8,6 +8,7 @@ using System.Runtime.ExceptionServices;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Practices.EnterpriseLibrary.SemanticLogging;
+using Microsoft.Practices.IoTJourney;
 using Microsoft.Practices.IoTJourney.WarmStorage.Logging;
 using Microsoft.ServiceBus;
 using Microsoft.WindowsAzure.Storage;
@@ -21,6 +22,11 @@ namespace WarmStorage.ConsoleHost
     {
         private static void Main(string[] args)
         {
+            AsyncPump.Run(() => MainAsync(args));
+        }
+
+        private static async Task MainAsync(string[] args)
+        {
             var observableEventListener = new ObservableEventListener();
 
             observableEventListener.EnableEvents(
@@ -28,7 +34,7 @@ namespace WarmStorage.ConsoleHost
 
             observableEventListener.LogToConsole();
 
-            CommonConsoleHost.WithOptions(new Dictionary<string, Func<CancellationToken, Task>>
+            await CommonConsoleHost.RunWithOptionsAsync(new Dictionary<string, Func<CancellationToken, Task>>
             {
                 { "Provision Resources", ProvisionResourcesAsync },
                 { "Run Warm Storage Consumer", RunAsync }


### PR DESCRIPTION
This PR addresses async concerns in the simulator:
- Adds [an async message pump](http://blogs.msdn.com/b/pfxteam/archive/2012/01/20/10259049.aspx).
- Removes blocking `.Wait()` call
- Improves the console integration (awaiting the `q` keypress)
- Renames the `WithOptions` method to `RunWithOptionsAsync` to properly reflect its purpose.

As part of this, I investigated #9, but did not find any measurable benefit of setting any of the tasks with `TaskCreationOptions.LongRunning` .

connects to #9
