### PR TITLE
Add command line options for web jobs

### DIFF
--- a/src/RunFromConsole/ScenarioSimulator.ConsoleHost/Program.cs
+++ b/src/RunFromConsole/ScenarioSimulator.ConsoleHost/Program.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Diagnostics.Tracing;
+using System.IO;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
@@ -13,6 +14,8 @@ namespace Microsoft.Practices.IoTJourney.ScenarioSimulator.ConsoleHost
 {
     internal class Program
     {
+        private static FileSystemWatcher _fileSystemWatcher;
+
         private static void Main(string[] args)
         {
             var observableEventListener = new ObservableEventListener();
@@ -26,6 +29,22 @@ namespace Microsoft.Practices.IoTJourney.ScenarioSimulator.ConsoleHost
 
             var deviceSimulator = new SimulationProfile("Console", 1, configuration);
 
+            // check for scenario specified on the command line
+            if (args.Length > 0)
+            {
+                var scenario = args.Contains("/default", StringComparer.OrdinalIgnoreCase)
+                    ? SimulationScenarios.DefaultScenario()
+                    : args.First(x => !x.StartsWith("/"));
+
+                var ct = args.Contains("/webjob", StringComparer.OrdinalIgnoreCase)
+                    ? GetWebJobCancellationToken()
+                    : CancellationToken.None;
+
+                deviceSimulator.RunSimulationAsync(scenario, ct).Wait(); // todo, use await after #138 is merged
+                return;
+            }
+
+            // no command line arguments, so prompt with a menu
             var options = SimulationScenarios
                 .AllScenarios
                 .ToDictionary(
@@ -33,6 +52,27 @@ namespace Microsoft.Practices.IoTJourney.ScenarioSimulator.ConsoleHost
                     scenario => (Func<CancellationToken, Task>)(token => deviceSimulator.RunSimulationAsync(scenario, token)));
 
             Tests.Common.ConsoleHost.WithOptions(options);
+        }
+        
+        private static CancellationToken GetWebJobCancellationToken()
+        {
+            // See: http://blog.amitapple.com/post/2014/05/webjobs-graceful-shutdown
+
+            var shutdownFile = Environment.GetEnvironmentVariable("WEBJOBS_SHUTDOWN_FILE");
+            var directory = Path.GetDirectoryName(shutdownFile);
+            if (directory == null)
+                return CancellationToken.None;
+
+            var cts = new CancellationTokenSource();
+            _fileSystemWatcher = new FileSystemWatcher(directory);
+            _fileSystemWatcher.Created += (sender, args) =>
+            {
+                if (args.FullPath.Equals(Path.GetFullPath(shutdownFile), StringComparison.OrdinalIgnoreCase))
+                    cts.Cancel();
+            };
+
+            _fileSystemWatcher.EnableRaisingEvents = true;
+            return cts.Token;
         }
     }
 }

--- a/src/RunFromConsole/ScenarioSimulator.ConsoleHost/ScenarioSimulator.ConsoleHost.csproj
+++ b/src/RunFromConsole/ScenarioSimulator.ConsoleHost/ScenarioSimulator.ConsoleHost.csproj
@@ -74,6 +74,9 @@
     <None Include="packages.config">
       <SubType>Designer</SubType>
     </None>
+    <Content Include="WebJob.cmd">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\Implementation\Simulator\ScenarioSimulator\ScenarioSimulator.csproj">

--- a/src/RunFromConsole/ScenarioSimulator.ConsoleHost/WebJob.cmd
+++ b/src/RunFromConsole/ScenarioSimulator.ConsoleHost/WebJob.cmd
@@ -1,0 +1,1 @@
+Microsoft.Practices.IoTJourney.ScenarioSimulator.ConsoleHost.exe /default /webjob


### PR DESCRIPTION
Implements the following command line options:

```
Microsoft.Practices.IoTJourney.ScenarioSimulator.ConsoleHost.exe [ <name> | /default ] [/webjob]
```
- `<name>` : runs the scenario name specified, if it exists.
  - Currently defined are: `NoErrorsExpected` and `ThirtyDegreeReadings`.
- `/default` : runs the default scenario, which is currently `NoErrorsExpected`.
- `/webjob` : enables the simulator to shutdown cleanly when ran as a web job.

Examples:

```
Microsoft.Practices.IoTJourney.ScenarioSimulator.ConsoleHost.exe /default
Microsoft.Practices.IoTJourney.ScenarioSimulator.ConsoleHost.exe /default /webjob
Microsoft.Practices.IoTJourney.ScenarioSimulator.ConsoleHost.exe ThirtyDegreeReadings /webjob
```

Calling with no parameters invokes the current menu-driven functionality.

Connects to #82.
