### PR TITLE
[do not merge] exploring the simulator problem

### DIFF
--- a/src/Implementation/Simulator/ScenarioSimulator/Device.cs
+++ b/src/Implementation/Simulator/ScenarioSimulator/Device.cs
@@ -61,7 +61,7 @@ namespace Microsoft.Practices.IoTJourney.ScenarioSimulator
                         entry.ResetElapsedTime();
 
                         var evt = entry.CreateNewEvent(this);
-                        var wasEventSent = await _sendEventAsync(evt);
+                        var wasEventSent = await _sendEventAsync(evt).ConfigureAwait(false);
 
                         if (wasEventSent)
                         {
@@ -77,7 +77,7 @@ namespace Microsoft.Practices.IoTJourney.ScenarioSimulator
                             // the next one.
                             try
                             {
-                                await Task.Delay(TimeSpan.FromSeconds(10), token);
+                                await Task.Delay(TimeSpan.FromSeconds(10), token).ConfigureAwait(false);
                             }
                             catch (TaskCanceledException) { /* cancelling Task.Delay will throw */ }
                         }

--- a/src/Implementation/Simulator/ScenarioSimulator/Device.cs
+++ b/src/Implementation/Simulator/ScenarioSimulator/Device.cs
@@ -14,8 +14,6 @@ namespace Microsoft.Practices.IoTJourney.ScenarioSimulator
 {
     public class Device
     {
-        private static readonly TimeSpan LoopFrequency = TimeSpan.FromSeconds(0.33);
-
         private readonly string _deviceId;
 
         private readonly IEnumerable<EventEntry> _eventEntries;
@@ -87,7 +85,7 @@ namespace Microsoft.Practices.IoTJourney.ScenarioSimulator
 
                     try
                     {
-                        await Task.Delay(LoopFrequency, token);
+                        await Task.Yield();
                     }
                     catch (TaskCanceledException) { /* cancelling Task.Delay will throw */ }
                 }

--- a/src/Implementation/Simulator/ScenarioSimulator/EventEntry.cs
+++ b/src/Implementation/Simulator/ScenarioSimulator/EventEntry.cs
@@ -46,7 +46,7 @@ namespace Microsoft.Practices.IoTJourney.ScenarioSimulator
         {
             _totalElapsedMilliseconds = 0;
 
-            var nextJitter = (_random.NextDouble() * _jitter);
+            var nextJitter = (_random.NextDouble() * 2 * _jitter) - _jitter;
             _frequencyWithJitter = _frequency + (nextJitter * _frequency);
         }
 

--- a/src/Implementation/Simulator/ScenarioSimulator/EventSender.cs
+++ b/src/Implementation/Simulator/ScenarioSimulator/EventSender.cs
@@ -41,7 +41,7 @@ namespace Microsoft.Practices.IoTJourney.ScenarioSimulator
                 {
                     var stopwatch = Stopwatch.StartNew();
 
-                    await this._eventHubClient.SendAsync(eventData);
+                    await this._eventHubClient.SendAsync(eventData).ConfigureAwait(false);
                     stopwatch.Stop();
 
                     ScenarioSimulatorEventSource.Log.EventSent(stopwatch.ElapsedTicks);

--- a/src/Implementation/Simulator/ScenarioSimulator/SimulationProfile.cs
+++ b/src/Implementation/Simulator/ScenarioSimulator/SimulationProfile.cs
@@ -92,7 +92,7 @@ namespace Microsoft.Practices.IoTJourney.ScenarioSimulator
                     simulationTasks.Add(deviceTask);
                 }
 
-                await Task.WhenAll(simulationTasks.ToArray());
+                await Task.WhenAll(simulationTasks.ToArray()).ConfigureAwait(false);
 
                 _observableTotalCount.OnCompleted();
             }
@@ -120,7 +120,7 @@ namespace Microsoft.Practices.IoTJourney.ScenarioSimulator
 
             try
             {
-                await Task.Delay(waitBeforeStarting, token);
+                await Task.Delay(waitBeforeStarting, token).ConfigureAwait(false);
             }
             catch (TaskCanceledException)
             {
@@ -137,7 +137,7 @@ namespace Microsoft.Practices.IoTJourney.ScenarioSimulator
             device.ObservableEventCount
                 .Subscribe(totalCount.OnNext);
 
-            await device.RunSimulationAsync(token);
+            await device.RunSimulationAsync(token).ConfigureAwait(false);
         }
     }
 }

--- a/src/Implementation/Simulator/ScenarioSimulator/SimulationProfile.cs
+++ b/src/Implementation/Simulator/ScenarioSimulator/SimulationProfile.cs
@@ -59,6 +59,14 @@ namespace Microsoft.Practices.IoTJourney.ScenarioSimulator
                 .Scan(0, (total, next) => total + next.Sum())
                 .Subscribe(total => ScenarioSimulatorEventSource.Log.CurrentEventCountForAllDevices(total));
 
+            var interval = TimeSpan.FromMinutes(0.1);
+            _observableTotalCount
+                .Buffer(interval)
+                .Scan(0, (total, next) => next.Sum())
+                .Subscribe(count =>
+                Console.WriteLine("{0} per second", (count / interval.TotalSeconds))
+                );
+
             try
             {
                 for (int i = 0; i < _devicesPerInstance; i++)

--- a/src/Implementation/Simulator/ScenarioSimulator/SimulatorConfiguration.cs
+++ b/src/Implementation/Simulator/ScenarioSimulator/SimulatorConfiguration.cs
@@ -30,7 +30,7 @@ namespace Microsoft.Practices.IoTJourney.ScenarioSimulator
                 EventHubPath = ConfigurationHelper.GetConfigValue<string>("Simulator.EventHubPath"),
                 NumberOfDevices = ConfigurationHelper.GetConfigValue<int>("Simulator.NumberOfDevices"),
                 SenderCountPerInstance = ConfigurationHelper.GetConfigValue("Simulator.SenderCountPerInstance", 5),
-                WarmupDuration = ConfigurationHelper.GetConfigValue("Simulator.WarmupDuration", TimeSpan.FromSeconds(30)),
+                WarmupDuration = ConfigurationHelper.GetConfigValue("Simulator.WarmUpDuration", TimeSpan.FromSeconds(30)),
                 Scenario = ConfigurationHelper.GetConfigValue<string>("Simulator.Scenario", String.Empty),
                 EventLevel = ConfigurationHelper.GetConfigValue<EventLevel>("Simulator.LogLevel", EventLevel.Informational)
             };


### PR DESCRIPTION
This is with respect to #161.

I can get good results with

``` xml
  <add key="Simulator.NumberOfDevices"
       value="2000"/>
  <add key="Simulator.SenderCountPerInstance"
       value="600"/>
```

However, if I up the `Simulator.NumberOfDevices` to **3,000** then I max out my CPU. 
Interestingly, if I replace [this line](https://github.com/mspnp/iot-journey/blob/bennage/simulator/src/Implementation/Simulator/ScenarioSimulator/EventSender.cs#L44)

``` C#
await this._eventHubClient.SendAsync(eventData).ConfigureAwait(false);
```

with this

``` C#
await Task.Delay(0).ConfigureAwait(false);
```

Then the CPU drops below 50%, and I average the expected 3,000 events per sec.
