### PR TITLE
fixed jitter and added unit test to validate

### DIFF
--- a/src/Simulator/ScenarioSimulator/EventEntry.cs
+++ b/src/Simulator/ScenarioSimulator/EventEntry.cs
@@ -46,7 +46,7 @@ namespace Microsoft.Practices.IoTJourney.ScenarioSimulator
         {
             _totalElapsedMilliseconds = 0;
 
-            var nextJitter = (_random.NextDouble() * _jitter);
+            var nextJitter = (_random.NextDouble() * 2 * _jitter) - _jitter;
             _frequencyWithJitter = _frequency + (nextJitter * _frequency);
         }
 


### PR DESCRIPTION
connects to #175 

The frequency jitter in the simulation was implemented incorrectly.  It only was additive to the frequency causing a positive bias which caused a delay in our message sending.  This appeared as 25% decrease in our throughput. 

In addition to fixing the jitter.  Added a unit test to validate we do oscillate around the frequency, which reflects what's expected in realistic jitter. 