### PR TITLE
Added Semantic Log Event for Current Events Per Second

### DIFF
--- a/src/Shared/Core/Logging/ScenarioSimulatorEventSource.cs
+++ b/src/Shared/Core/Logging/ScenarioSimulatorEventSource.cs
@@ -163,11 +163,10 @@ namespace Microsoft.Practices.IoTJourney.Logging
             WriteEvent(19, deviceId, eventCount);
         }
 
-        [Event(20, Level = EventLevel.Informational)]
-        public void CurrentEventsPerSecond(string EventsPerSecond)
+        [Event(20, Level = EventLevel.Informational, Message = "{0:0.00} per second")]
+        public void CurrentEventsPerSecond(double eventsPerSecond)
         {
-            WriteEvent(20, EventsPerSecond);
+            WriteEvent(20, eventsPerSecond);
         }
-
     }
 }

--- a/src/Shared/Core/Logging/ScenarioSimulatorEventSource.cs
+++ b/src/Shared/Core/Logging/ScenarioSimulatorEventSource.cs
@@ -162,5 +162,12 @@ namespace Microsoft.Practices.IoTJourney.Logging
         {
             WriteEvent(19, deviceId, eventCount);
         }
+
+        [Event(20, Level = EventLevel.Informational)]
+        public void CurrentEventsPerSecond(string EventsPerSecond)
+        {
+            WriteEvent(20, EventsPerSecond);
+        }
+
     }
 }

--- a/src/Simulator/ScenarioSimulator/SimulationProfile.cs
+++ b/src/Simulator/ScenarioSimulator/SimulationProfile.cs
@@ -95,6 +95,12 @@ namespace Microsoft.Practices.IoTJourney.ScenarioSimulator
                 .Scan(0, (total, next) => total + next.Sum())
                 .Subscribe(total => ScenarioSimulatorEventSource.Log.CurrentEventCountForAllDevices(total));
 
+            var interval = TimeSpan.FromMinutes(0.1);
+            _observableTotalCount
+                .Buffer(interval)
+                .Scan(0, (total, next) => next.Sum())
+                .Subscribe(count => ScenarioSimulatorEventSource.Log.CurrentEventsPerSecond(String.Format("{0} per second", (count / interval.TotalSeconds))));
+
             foreach (var device in _devices)
             {
                 var eventSender = new EventSender(

--- a/src/Simulator/ScenarioSimulator/SimulationProfile.cs
+++ b/src/Simulator/ScenarioSimulator/SimulationProfile.cs
@@ -96,14 +96,11 @@ namespace Microsoft.Practices.IoTJourney.ScenarioSimulator
                 .Scan(0, (total, next) => total + next.Sum())
                 .Subscribe(total => ScenarioSimulatorEventSource.Log.CurrentEventCountForAllDevices(total));
 
-            var sw = new Stopwatch();
-            sw.Start();
             _observableTotalCount
                 .Buffer(TimeSpan.FromMinutes(0.1))
-                .Scan(0, (total, next) => next.Sum())
-                .Subscribe(count => {
-                    var rate = count/sw.Elapsed.TotalSeconds;
-                    sw.Restart();
+                .TimeInterval()
+                .Select(x => x.Value.Sum()/x.Interval.TotalSeconds)
+                .Subscribe(rate => {
                     ScenarioSimulatorEventSource.Log.CurrentEventsPerSecond(String.Format("{0:0.00} per second", rate));
                 });
 

--- a/src/Simulator/ScenarioSimulator/SimulationProfile.cs
+++ b/src/Simulator/ScenarioSimulator/SimulationProfile.cs
@@ -85,7 +85,7 @@ namespace Microsoft.Practices.IoTJourney.ScenarioSimulator
                 .Buffer(TimeSpan.FromMinutes(0.1))
                 .TimeInterval()
                 .Select(x => x.Value.Sum() / x.Interval.TotalSeconds)
-                .Subscribe(rate => ScenarioSimulatorEventSource.Log.CurrentEventsPerSecond(String.Format("{0:0.00} per second", rate)));
+                .Subscribe(rate => ScenarioSimulatorEventSource.Log.CurrentEventsPerSecond(rate));
         }
 
         public async Task RunSimulationAsync(string scenario, CancellationToken token)


### PR DESCRIPTION
connects to #176 

This adds a new semantic log event that captures the current through in
terms of events per second.