### PR TITLE
Device provisioning Web API

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -200,6 +200,5 @@ FakesAssemblies/
 *.azurePubXml
 
 *-local.config
-WarmStorage.EventProcessor.ConsoleHost.config
-ColdStorage.EventProcessor.ConsoleHost.config
-ScenarioSimulator.ConsoleHost.config
+*.ConsoleHost.config
+settings.config

--- a/src/DeviceProvisioning/ProvisioningWebApi/ProvisioningWebApi.ConsoleHost/App.config
+++ b/src/DeviceProvisioning/ProvisioningWebApi/ProvisioningWebApi.ConsoleHost/App.config
@@ -1,0 +1,56 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+    <startup> 
+        <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.5.1" />
+    </startup>
+
+  <appSettings file="settings.config">
+  </appSettings>
+
+  <runtime>
+    <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
+      <dependentAssembly>
+        <assemblyIdentity name="Microsoft.Data.Edm" publicKeyToken="31bf3856ad364e35" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-5.6.4.0" newVersion="5.6.4.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="Microsoft.Data.Services.Client" publicKeyToken="31bf3856ad364e35" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-5.6.4.0" newVersion="5.6.4.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="Microsoft.Data.OData" publicKeyToken="31bf3856ad364e35" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-5.6.4.0" newVersion="5.6.4.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="Newtonsoft.Json" publicKeyToken="30ad4fe6b2a6aeed" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-6.0.0.0" newVersion="6.0.0.0" />
+      </dependentAssembly>
+    </assemblyBinding>
+  </runtime>
+  <system.serviceModel>
+    <extensions>
+      <!-- In this extension section we are introducing all known service bus extensions. User can remove the ones they don't need. -->
+      <behaviorExtensions>
+        <add name="connectionStatusBehavior" type="Microsoft.ServiceBus.Configuration.ConnectionStatusElement, Microsoft.ServiceBus, Culture=neutral, PublicKeyToken=31bf3856ad364e35" />
+        <add name="transportClientEndpointBehavior" type="Microsoft.ServiceBus.Configuration.TransportClientEndpointBehaviorElement, Microsoft.ServiceBus, Culture=neutral, PublicKeyToken=31bf3856ad364e35" />
+        <add name="serviceRegistrySettings" type="Microsoft.ServiceBus.Configuration.ServiceRegistrySettingsElement, Microsoft.ServiceBus, Culture=neutral, PublicKeyToken=31bf3856ad364e35" />
+      </behaviorExtensions>
+      <bindingElementExtensions>
+        <add name="netMessagingTransport" type="Microsoft.ServiceBus.Messaging.Configuration.NetMessagingTransportExtensionElement, Microsoft.ServiceBus,  Culture=neutral, PublicKeyToken=31bf3856ad364e35" />
+        <add name="tcpRelayTransport" type="Microsoft.ServiceBus.Configuration.TcpRelayTransportElement, Microsoft.ServiceBus, Culture=neutral, PublicKeyToken=31bf3856ad364e35" />
+        <add name="httpRelayTransport" type="Microsoft.ServiceBus.Configuration.HttpRelayTransportElement, Microsoft.ServiceBus, Culture=neutral, PublicKeyToken=31bf3856ad364e35" />
+        <add name="httpsRelayTransport" type="Microsoft.ServiceBus.Configuration.HttpsRelayTransportElement, Microsoft.ServiceBus, Culture=neutral, PublicKeyToken=31bf3856ad364e35" />
+        <add name="onewayRelayTransport" type="Microsoft.ServiceBus.Configuration.RelayedOnewayTransportElement, Microsoft.ServiceBus, Culture=neutral, PublicKeyToken=31bf3856ad364e35" />
+      </bindingElementExtensions>
+      <bindingExtensions>
+        <add name="basicHttpRelayBinding" type="Microsoft.ServiceBus.Configuration.BasicHttpRelayBindingCollectionElement, Microsoft.ServiceBus, Culture=neutral, PublicKeyToken=31bf3856ad364e35" />
+        <add name="webHttpRelayBinding" type="Microsoft.ServiceBus.Configuration.WebHttpRelayBindingCollectionElement, Microsoft.ServiceBus, Culture=neutral, PublicKeyToken=31bf3856ad364e35" />
+        <add name="ws2007HttpRelayBinding" type="Microsoft.ServiceBus.Configuration.WS2007HttpRelayBindingCollectionElement, Microsoft.ServiceBus, Culture=neutral, PublicKeyToken=31bf3856ad364e35" />
+        <add name="netTcpRelayBinding" type="Microsoft.ServiceBus.Configuration.NetTcpRelayBindingCollectionElement, Microsoft.ServiceBus, Culture=neutral, PublicKeyToken=31bf3856ad364e35" />
+        <add name="netOnewayRelayBinding" type="Microsoft.ServiceBus.Configuration.NetOnewayRelayBindingCollectionElement, Microsoft.ServiceBus, Culture=neutral, PublicKeyToken=31bf3856ad364e35" />
+        <add name="netEventRelayBinding" type="Microsoft.ServiceBus.Configuration.NetEventRelayBindingCollectionElement, Microsoft.ServiceBus, Culture=neutral, PublicKeyToken=31bf3856ad364e35" />
+        <add name="netMessagingBinding" type="Microsoft.ServiceBus.Messaging.Configuration.NetMessagingBindingCollectionElement, Microsoft.ServiceBus, Culture=neutral, PublicKeyToken=31bf3856ad364e35" />
+      </bindingExtensions>
+    </extensions>
+  </system.serviceModel>
+</configuration>

--- a/src/DeviceProvisioning/ProvisioningWebApi/ProvisioningWebApi.ConsoleHost/Program.cs
+++ b/src/DeviceProvisioning/ProvisioningWebApi/ProvisioningWebApi.ConsoleHost/Program.cs
@@ -1,0 +1,69 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Microsoft.Practices.IoTJourney;
+using Microsoft.Practices.IoTJourney.DeviceProvisioningModels;
+using Microsoft.ServiceBus;
+using Microsoft.ServiceBus.Messaging;
+using System;
+using System.Collections.Generic;
+using System.Net.Http;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using CommonConsoleHost = Microsoft.Practices.IoTJourney.Tests.Common.ConsoleHost;
+
+namespace ProvisioningWebApi.ConsoleHost
+{
+    internal class Program
+    {
+        private static void Main(string[] args)
+        {
+            CommonConsoleHost.RunWithOptionsAsync(new Dictionary<string, Func<CancellationToken, Task>>
+            {
+                { "Provision a device", ProvisionDeviceAsync }
+            }).Wait();
+        }
+
+        private static async Task ProvisionDeviceAsync(CancellationToken token)
+        {
+            string baseUrl = ConfigurationHelper.GetConfigValue<string>("WebApiEndpoint");
+
+            HttpClient client = new HttpClient();
+            client.BaseAddress = new Uri(baseUrl);
+
+            var device = new Device
+            {
+                DeviceId = Guid.NewGuid().ToString()
+            };
+
+            var result = await client.PostAsJsonAsync("api/provision", device);
+
+            if (result.IsSuccessStatusCode)
+            {
+                var endpoint = await result.Content.ReadAsAsync<DeviceEndpoint>();
+
+                Console.WriteLine("Endpoint: {0}", endpoint.Uri);
+                Console.WriteLine("AccessToken: {0}", endpoint.AccessToken);
+
+                var connectionString = ServiceBusConnectionStringBuilder.CreateUsingSharedAccessSignature(
+                                        new Uri(endpoint.Uri),
+                                        endpoint.EventHubName,
+                                        device.DeviceId,
+                                        endpoint.AccessToken
+                                  );
+
+                var sender = EventHubSender.CreateFromConnectionString(connectionString);
+
+                sender.Send(new EventData(Encoding.UTF8.GetBytes("Hello Event Hub")));
+
+                Console.WriteLine("Wrote data to event hub");
+            }
+            else
+            {
+                var str = await result.Content.ReadAsStringAsync();
+                Console.WriteLine(str);
+            }
+        }
+    }
+}

--- a/src/DeviceProvisioning/ProvisioningWebApi/ProvisioningWebApi.ConsoleHost/Program.cs
+++ b/src/DeviceProvisioning/ProvisioningWebApi/ProvisioningWebApi.ConsoleHost/Program.cs
@@ -37,11 +37,11 @@ namespace ProvisioningWebApi.ConsoleHost
                 DeviceId = Guid.NewGuid().ToString()
             };
 
-            var result = await client.PostAsJsonAsync("api/provision", device);
+            var result = await client.PostAsJsonAsync("api/provision", device, token);
 
             if (result.IsSuccessStatusCode)
             {
-                var endpoint = await result.Content.ReadAsAsync<DeviceEndpoint>();
+                var endpoint = await result.Content.ReadAsAsync<DeviceEndpoint>(token);
 
                 Console.WriteLine("Endpoint: {0}", endpoint.Uri);
                 Console.WriteLine("AccessToken: {0}", endpoint.AccessToken);

--- a/src/DeviceProvisioning/ProvisioningWebApi/ProvisioningWebApi.ConsoleHost/Properties/AssemblyInfo.cs
+++ b/src/DeviceProvisioning/ProvisioningWebApi/ProvisioningWebApi.ConsoleHost/Properties/AssemblyInfo.cs
@@ -1,0 +1,36 @@
+﻿using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+// General Information about an assembly is controlled through the following 
+// set of attributes. Change these attribute values to modify the information
+// associated with an assembly.
+[assembly: AssemblyTitle("ProvisioningWebApi.ConsoleHost")]
+[assembly: AssemblyDescription("")]
+[assembly: AssemblyConfiguration("")]
+[assembly: AssemblyCompany("")]
+[assembly: AssemblyProduct("ProvisioningWebApi.ConsoleHost")]
+[assembly: AssemblyCopyright("Copyright ©  2015")]
+[assembly: AssemblyTrademark("")]
+[assembly: AssemblyCulture("")]
+
+// Setting ComVisible to false makes the types in this assembly not visible 
+// to COM components.  If you need to access a type in this assembly from 
+// COM, set the ComVisible attribute to true on that type.
+[assembly: ComVisible(false)]
+
+// The following GUID is for the ID of the typelib if this project is exposed to COM
+[assembly: Guid("ff8df0eb-cdc3-462f-b361-55bba6d3cd03")]
+
+// Version information for an assembly consists of the following four values:
+//
+//      Major Version
+//      Minor Version 
+//      Build Number
+//      Revision
+//
+// You can specify all the values or you can default the Build and Revision Numbers 
+// by using the '*' as shown below:
+// [assembly: AssemblyVersion("1.0.*")]
+[assembly: AssemblyVersion("1.0.0.0")]
+[assembly: AssemblyFileVersion("1.0.0.0")]

--- a/src/DeviceProvisioning/ProvisioningWebApi/ProvisioningWebApi.ConsoleHost/ProvisioningWebApi.ConsoleHost.csproj
+++ b/src/DeviceProvisioning/ProvisioningWebApi/ProvisioningWebApi.ConsoleHost/ProvisioningWebApi.ConsoleHost.csproj
@@ -1,0 +1,90 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProjectGuid>{59DEF0F3-DEA3-4E34-BA07-4BB166E55BCD}</ProjectGuid>
+    <OutputType>Exe</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <RootNamespace>ProvisioningWebApi.ConsoleHost</RootNamespace>
+    <AssemblyName>ProvisioningWebApi.ConsoleHost</AssemblyName>
+    <TargetFrameworkVersion>v4.5.1</TargetFrameworkVersion>
+    <FileAlignment>512</FileAlignment>
+    <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <PlatformTarget>AnyCPU</PlatformTarget>
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\Debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <PlatformTarget>AnyCPU</PlatformTarget>
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>bin\Release\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="Microsoft.ServiceBus, Version=2.7.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <SpecificVersion>False</SpecificVersion>
+      <HintPath>..\..\..\packages\WindowsAzure.ServiceBus.2.7.2\lib\net40-full\Microsoft.ServiceBus.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.WindowsAzure.Configuration">
+      <HintPath>..\..\..\packages\Microsoft.WindowsAzure.ConfigurationManager.3.1.0\lib\net40\Microsoft.WindowsAzure.Configuration.dll</HintPath>
+    </Reference>
+    <Reference Include="Newtonsoft.Json">
+      <HintPath>..\..\..\packages\Newtonsoft.Json.6.0.4\lib\net45\Newtonsoft.Json.dll</HintPath>
+    </Reference>
+    <Reference Include="System" />
+    <Reference Include="System.Core" />
+    <Reference Include="System.Net.Http" />
+    <Reference Include="System.Net.Http.Formatting, Version=5.2.3.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <SpecificVersion>False</SpecificVersion>
+      <HintPath>..\..\..\packages\Microsoft.AspNet.WebApi.Client.5.2.3\lib\net45\System.Net.Http.Formatting.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Runtime.Serialization" />
+    <Reference Include="System.ServiceModel" />
+    <Reference Include="System.Xml.Linq" />
+    <Reference Include="System.Data.DataSetExtensions" />
+    <Reference Include="Microsoft.CSharp" />
+    <Reference Include="System.Data" />
+    <Reference Include="System.Xml" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="Program.cs" />
+    <Compile Include="Properties\AssemblyInfo.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="App.config" />
+    <None Include="packages.config" />
+    <None Include="settings.config">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </None>
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\..\Shared\Core\Core.csproj">
+      <Project>{b3657b80-640f-4d72-885e-e9f9729bac18}</Project>
+      <Name>Core</Name>
+    </ProjectReference>
+    <ProjectReference Include="..\..\..\Shared\Tests.Common\Tests.Common.csproj">
+      <Project>{769c50c0-1627-4834-824a-a77b2c303f9d}</Project>
+      <Name>Tests.Common</Name>
+    </ProjectReference>
+  </ItemGroup>
+  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
+       Other similar extension points exist, see Microsoft.Common.targets.
+  <Target Name="BeforeBuild">
+  </Target>
+  <Target Name="AfterBuild">
+  </Target>
+  -->
+</Project>

--- a/src/DeviceProvisioning/ProvisioningWebApi/ProvisioningWebApi.ConsoleHost/packages.config
+++ b/src/DeviceProvisioning/ProvisioningWebApi/ProvisioningWebApi.ConsoleHost/packages.config
@@ -1,0 +1,7 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="Microsoft.AspNet.WebApi.Client" version="5.2.3" targetFramework="net451" />
+  <package id="Microsoft.WindowsAzure.ConfigurationManager" version="3.1.0" targetFramework="net451" />
+  <package id="Newtonsoft.Json" version="6.0.4" targetFramework="net451" />
+  <package id="WindowsAzure.ServiceBus" version="2.7.2" targetFramework="net451" />
+</packages>

--- a/src/DeviceProvisioning/ProvisioningWebApi/ProvisioningWebApi.ConsoleHost/settings.template.config
+++ b/src/DeviceProvisioning/ProvisioningWebApi/ProvisioningWebApi.ConsoleHost/settings.template.config
@@ -1,0 +1,4 @@
+﻿<?xml version="1.0"?>
+  <appSettings>
+    <add key="WebApiEndpoint" value="[Root URL of web api]"/>
+  </appSettings>

--- a/src/DeviceProvisioning/ProvisioningWebApi/ProvisioningWebApi.Tests/GivenAProvisionController.cs
+++ b/src/DeviceProvisioning/ProvisioningWebApi/ProvisioningWebApi.Tests/GivenAProvisionController.cs
@@ -1,0 +1,81 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using DeviceProvisioning.AccessTokens;
+using DeviceProvisioning.Controllers;
+using DeviceProvisioning.DeviceRegistry;
+using Microsoft.Practices.IoTJourney.DeviceProvisioningModels;
+using Moq;
+using System;
+using System.Threading.Tasks;
+using System.Web.Http;
+using System.Web.Http.Results;
+using Xunit;
+
+namespace DeviceProvisioning.Tests
+{
+    public class WhenProvisioning
+    {
+        private ProvisionController _controller;
+        private Mock<ITokenProvider> _tokenProvider;
+        private Mock<IDeviceRegistry> _registry;
+
+        const string TOKEN = "TOKEN";
+
+        public WhenProvisioning()
+        {
+            _tokenProvider = new Mock<ITokenProvider>();
+            _tokenProvider.Setup(x => x.GetTokenAsync(It.IsAny<string>()))
+                .ReturnsAsync(TOKEN);
+            _tokenProvider.Setup(x => x.EndpointUri).Returns(new Uri("http://example.com"));
+
+            _registry = new Mock<IDeviceRegistry>();
+            _registry.Setup(x => x.AddOrUpdate(It.IsAny<DeviceInfo>()))
+                .ReturnsAsync(true);
+            
+            _controller = new ProvisionController(_tokenProvider.Object, _registry.Object);
+        }
+
+        [Fact]
+        public async Task ReturnsToken()
+        {
+            Device device = new Device { DeviceId = "1" };
+            IHttpActionResult actionResult = await _controller.ProvisionDevice(device);
+
+            var contentResult = actionResult as OkNegotiatedContentResult<DeviceEndpoint>;
+
+            Assert.NotNull(contentResult);
+            Assert.NotNull(contentResult.Content);
+            Assert.Equal(TOKEN, contentResult.Content.AccessToken);
+        }
+
+        [Fact]
+        public async Task AddsRegistryEntry()
+        {
+            Device device = new Device { DeviceId = "1" };
+
+            await _controller.ProvisionDevice(device);
+
+            _registry.Verify(mock => mock.AddOrUpdate(It.IsAny<DeviceInfo>()));
+        }
+
+
+        [Fact]
+        public async Task NullModelReturnsBadRequest()
+        {
+            IHttpActionResult actionResult = await _controller.ProvisionDevice(null);
+            Assert.IsType<BadRequestErrorMessageResult>(actionResult);
+        }
+
+        [Fact]
+        public async Task NoDeviceIdReturnsBadRequest()
+        {
+            Device device = new Device { DeviceId = "1" };
+
+            _controller.ModelState.AddModelError("FakeError", "FakeError");
+
+            IHttpActionResult actionResult = await _controller.ProvisionDevice(device);
+            Assert.IsType<InvalidModelStateResult>(actionResult);
+        }
+    }
+}

--- a/src/DeviceProvisioning/ProvisioningWebApi/ProvisioningWebApi.Tests/Properties/AssemblyInfo.cs
+++ b/src/DeviceProvisioning/ProvisioningWebApi/ProvisioningWebApi.Tests/Properties/AssemblyInfo.cs
@@ -1,0 +1,36 @@
+﻿using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+// General Information about an assembly is controlled through the following 
+// set of attributes. Change these attribute values to modify the information
+// associated with an assembly.
+[assembly: AssemblyTitle("ProvisioningWebApi.Tests")]
+[assembly: AssemblyDescription("")]
+[assembly: AssemblyConfiguration("")]
+[assembly: AssemblyCompany("")]
+[assembly: AssemblyProduct("ProvisioningWebApi.Tests")]
+[assembly: AssemblyCopyright("Copyright ©  2015")]
+[assembly: AssemblyTrademark("")]
+[assembly: AssemblyCulture("")]
+
+// Setting ComVisible to false makes the types in this assembly not visible 
+// to COM components.  If you need to access a type in this assembly from 
+// COM, set the ComVisible attribute to true on that type.
+[assembly: ComVisible(false)]
+
+// The following GUID is for the ID of the typelib if this project is exposed to COM
+[assembly: Guid("15a3c7be-b1ce-4ca7-93d3-f53827149085")]
+
+// Version information for an assembly consists of the following four values:
+//
+//      Major Version
+//      Minor Version 
+//      Build Number
+//      Revision
+//
+// You can specify all the values or you can default the Build and Revision Numbers 
+// by using the '*' as shown below:
+// [assembly: AssemblyVersion("1.0.*")]
+[assembly: AssemblyVersion("1.0.0.0")]
+[assembly: AssemblyFileVersion("1.0.0.0")]

--- a/src/DeviceProvisioning/ProvisioningWebApi/ProvisioningWebApi.Tests/ProvisioningWebApi.Tests.csproj
+++ b/src/DeviceProvisioning/ProvisioningWebApi/ProvisioningWebApi.Tests/ProvisioningWebApi.Tests.csproj
@@ -1,0 +1,108 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="..\..\..\packages\xunit.runner.visualstudio.2.0.0\build\net20\xunit.runner.visualstudio.props" Condition="Exists('..\..\..\packages\xunit.runner.visualstudio.2.0.0\build\net20\xunit.runner.visualstudio.props')" />
+  <Import Project="..\..\..\packages\xunit.core.2.0.0\build\portable-net45+win+wpa81+wp80+monotouch+monoandroid+Xamarin.iOS\xunit.core.props" Condition="Exists('..\..\..\packages\xunit.core.2.0.0\build\portable-net45+win+wpa81+wp80+monotouch+monoandroid+Xamarin.iOS\xunit.core.props')" />
+  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProjectGuid>{97C4DE76-FA81-42A0-BB6F-8040CAB1EAC2}</ProjectGuid>
+    <OutputType>Library</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <RootNamespace>ProvisioningWebApi.Tests</RootNamespace>
+    <AssemblyName>ProvisioningWebApi.Tests</AssemblyName>
+    <TargetFrameworkVersion>v4.5.1</TargetFrameworkVersion>
+    <FileAlignment>512</FileAlignment>
+    <NuGetPackageImportStamp>981f8749</NuGetPackageImportStamp>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\Debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>bin\Release\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="Moq">
+      <HintPath>..\..\..\packages\Moq.4.2.1502.0911\lib\net40\Moq.dll</HintPath>
+    </Reference>
+    <Reference Include="Newtonsoft.Json">
+      <HintPath>..\..\..\packages\Newtonsoft.Json.6.0.4\lib\net45\Newtonsoft.Json.dll</HintPath>
+    </Reference>
+    <Reference Include="System" />
+    <Reference Include="System.Core" />
+    <Reference Include="System.Net.Http" />
+    <Reference Include="System.Net.Http.Formatting, Version=5.2.3.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <SpecificVersion>False</SpecificVersion>
+      <HintPath>..\..\..\packages\Microsoft.AspNet.WebApi.Client.5.2.3\lib\net45\System.Net.Http.Formatting.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Web.Http, Version=5.2.3.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <SpecificVersion>False</SpecificVersion>
+      <HintPath>..\..\..\packages\Microsoft.AspNet.WebApi.Core.5.2.3\lib\net45\System.Web.Http.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Web.Http.WebHost, Version=5.2.3.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <SpecificVersion>False</SpecificVersion>
+      <HintPath>..\..\..\packages\Microsoft.AspNet.WebApi.WebHost.5.2.3\lib\net45\System.Web.Http.WebHost.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Xml.Linq" />
+    <Reference Include="System.Data.DataSetExtensions" />
+    <Reference Include="Microsoft.CSharp" />
+    <Reference Include="System.Data" />
+    <Reference Include="System.Xml" />
+    <Reference Include="xunit.abstractions">
+      <HintPath>..\..\..\packages\xunit.abstractions.2.0.0\lib\net35\xunit.abstractions.dll</HintPath>
+    </Reference>
+    <Reference Include="xunit.assert">
+      <HintPath>..\..\..\packages\xunit.assert.2.0.0\lib\portable-net45+win+wpa81+wp80+monotouch+monoandroid+Xamarin.iOS\xunit.assert.dll</HintPath>
+    </Reference>
+    <Reference Include="xunit.core">
+      <HintPath>..\..\..\packages\xunit.extensibility.core.2.0.0\lib\portable-net45+win+wpa81+wp80+monotouch+monoandroid+Xamarin.iOS\xunit.core.dll</HintPath>
+    </Reference>
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="GivenAProvisionController.cs" />
+    <Compile Include="Properties\AssemblyInfo.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\..\Shared\Core\Core.csproj">
+      <Project>{b3657b80-640f-4d72-885e-e9f9729bac18}</Project>
+      <Name>Core</Name>
+    </ProjectReference>
+    <ProjectReference Include="..\ProvisioningWebApi\ProvisioningWebApi.csproj">
+      <Project>{929cbb8f-cfe3-4a2c-8f89-c7fe63080400}</Project>
+      <Name>ProvisioningWebApi</Name>
+    </ProjectReference>
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="app.config" />
+    <None Include="packages.config" />
+  </ItemGroup>
+  <ItemGroup>
+    <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
+  </ItemGroup>
+  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
+    <PropertyGroup>
+      <ErrorText>This project references NuGet package(s) that are missing on this computer. Enable NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
+    </PropertyGroup>
+    <Error Condition="!Exists('..\..\..\packages\xunit.core.2.0.0\build\portable-net45+win+wpa81+wp80+monotouch+monoandroid+Xamarin.iOS\xunit.core.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\packages\xunit.core.2.0.0\build\portable-net45+win+wpa81+wp80+monotouch+monoandroid+Xamarin.iOS\xunit.core.props'))" />
+    <Error Condition="!Exists('..\..\..\packages\xunit.runner.visualstudio.2.0.0\build\net20\xunit.runner.visualstudio.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\packages\xunit.runner.visualstudio.2.0.0\build\net20\xunit.runner.visualstudio.props'))" />
+  </Target>
+  <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
+       Other similar extension points exist, see Microsoft.Common.targets.
+  <Target Name="BeforeBuild">
+  </Target>
+  <Target Name="AfterBuild">
+  </Target>
+  -->
+</Project>

--- a/src/DeviceProvisioning/ProvisioningWebApi/ProvisioningWebApi.Tests/app.config
+++ b/src/DeviceProvisioning/ProvisioningWebApi/ProvisioningWebApi.Tests/app.config
@@ -1,0 +1,31 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <runtime>
+    <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
+      <dependentAssembly>
+        <assemblyIdentity name="System.Web.Http" publicKeyToken="31bf3856ad364e35" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-5.2.3.0" newVersion="5.2.3.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.Net.Http.Formatting" publicKeyToken="31bf3856ad364e35" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-5.2.3.0" newVersion="5.2.3.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="Microsoft.Data.Edm" publicKeyToken="31bf3856ad364e35" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-5.6.4.0" newVersion="5.6.4.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="Microsoft.Data.Services.Client" publicKeyToken="31bf3856ad364e35" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-5.6.4.0" newVersion="5.6.4.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="Microsoft.Data.OData" publicKeyToken="31bf3856ad364e35" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-5.6.4.0" newVersion="5.6.4.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="Newtonsoft.Json" publicKeyToken="30ad4fe6b2a6aeed" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-6.0.0.0" newVersion="6.0.0.0" />
+      </dependentAssembly>
+    </assemblyBinding>
+  </runtime>
+</configuration>

--- a/src/DeviceProvisioning/ProvisioningWebApi/ProvisioningWebApi.Tests/packages.config
+++ b/src/DeviceProvisioning/ProvisioningWebApi/ProvisioningWebApi.Tests/packages.config
@@ -1,0 +1,15 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="Microsoft.AspNet.WebApi" version="5.2.3" targetFramework="net451" />
+  <package id="Microsoft.AspNet.WebApi.Client" version="5.2.3" targetFramework="net451" />
+  <package id="Microsoft.AspNet.WebApi.Core" version="5.2.3" targetFramework="net451" />
+  <package id="Microsoft.AspNet.WebApi.WebHost" version="5.2.3" targetFramework="net451" />
+  <package id="Moq" version="4.2.1502.0911" targetFramework="net451" />
+  <package id="Newtonsoft.Json" version="6.0.4" targetFramework="net451" />
+  <package id="xunit" version="2.0.0" targetFramework="net451" />
+  <package id="xunit.abstractions" version="2.0.0" targetFramework="net451" />
+  <package id="xunit.assert" version="2.0.0" targetFramework="net451" />
+  <package id="xunit.core" version="2.0.0" targetFramework="net451" />
+  <package id="xunit.extensibility.core" version="2.0.0" targetFramework="net451" />
+  <package id="xunit.runner.visualstudio" version="2.0.0" targetFramework="net451" />
+</packages>

--- a/src/DeviceProvisioning/ProvisioningWebApi/ProvisioningWebApi.sln
+++ b/src/DeviceProvisioning/ProvisioningWebApi/ProvisioningWebApi.sln
@@ -1,0 +1,59 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio 2013
+VisualStudioVersion = 12.0.31101.0
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Core", "..\..\Shared\Core\Core.csproj", "{B3657B80-640F-4D72-885E-E9F9729BAC18}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ProvisioningWebApi", "ProvisioningWebApi\ProvisioningWebApi.csproj", "{929CBB8F-CFE3-4A2C-8F89-C7FE63080400}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ProvisioningWebApi.Tests", "ProvisioningWebApi.Tests\ProvisioningWebApi.Tests.csproj", "{97C4DE76-FA81-42A0-BB6F-8040CAB1EAC2}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ProvisioningWebApi.ConsoleHost", "ProvisioningWebApi.ConsoleHost\ProvisioningWebApi.ConsoleHost.csproj", "{59DEF0F3-DEA3-4E34-BA07-4BB166E55BCD}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Tests.Common", "..\..\Shared\Tests.Common\Tests.Common.csproj", "{769C50C0-1627-4834-824A-A77B2C303F9D}"
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Shared", "Shared", "{22048A5B-F27B-4291-8462-DC9D7D075500}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Core.Tests", "..\..\Shared\Core.Tests\Core.Tests.csproj", "{3143B976-6447-4337-A868-5457CEC540ED}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{B3657B80-640F-4D72-885E-E9F9729BAC18}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{B3657B80-640F-4D72-885E-E9F9729BAC18}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{B3657B80-640F-4D72-885E-E9F9729BAC18}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{B3657B80-640F-4D72-885E-E9F9729BAC18}.Release|Any CPU.Build.0 = Release|Any CPU
+		{929CBB8F-CFE3-4A2C-8F89-C7FE63080400}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{929CBB8F-CFE3-4A2C-8F89-C7FE63080400}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{929CBB8F-CFE3-4A2C-8F89-C7FE63080400}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{929CBB8F-CFE3-4A2C-8F89-C7FE63080400}.Release|Any CPU.Build.0 = Release|Any CPU
+		{97C4DE76-FA81-42A0-BB6F-8040CAB1EAC2}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{97C4DE76-FA81-42A0-BB6F-8040CAB1EAC2}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{97C4DE76-FA81-42A0-BB6F-8040CAB1EAC2}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{97C4DE76-FA81-42A0-BB6F-8040CAB1EAC2}.Release|Any CPU.Build.0 = Release|Any CPU
+		{59DEF0F3-DEA3-4E34-BA07-4BB166E55BCD}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{59DEF0F3-DEA3-4E34-BA07-4BB166E55BCD}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{59DEF0F3-DEA3-4E34-BA07-4BB166E55BCD}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{59DEF0F3-DEA3-4E34-BA07-4BB166E55BCD}.Release|Any CPU.Build.0 = Release|Any CPU
+		{769C50C0-1627-4834-824A-A77B2C303F9D}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{769C50C0-1627-4834-824A-A77B2C303F9D}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{769C50C0-1627-4834-824A-A77B2C303F9D}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{769C50C0-1627-4834-824A-A77B2C303F9D}.Release|Any CPU.Build.0 = Release|Any CPU
+		{3143B976-6447-4337-A868-5457CEC540ED}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{3143B976-6447-4337-A868-5457CEC540ED}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{3143B976-6447-4337-A868-5457CEC540ED}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{3143B976-6447-4337-A868-5457CEC540ED}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(NestedProjects) = preSolution
+		{B3657B80-640F-4D72-885E-E9F9729BAC18} = {22048A5B-F27B-4291-8462-DC9D7D075500}
+		{769C50C0-1627-4834-824A-A77B2C303F9D} = {22048A5B-F27B-4291-8462-DC9D7D075500}
+		{3143B976-6447-4337-A868-5457CEC540ED} = {22048A5B-F27B-4291-8462-DC9D7D075500}
+	EndGlobalSection
+EndGlobal

--- a/src/DeviceProvisioning/ProvisioningWebApi/ProvisioningWebApi/App_Start/AutoFacConfig.cs
+++ b/src/DeviceProvisioning/ProvisioningWebApi/ProvisioningWebApi/App_Start/AutoFacConfig.cs
@@ -1,0 +1,28 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Autofac;
+using Autofac.Integration.WebApi;
+using DeviceProvisioning.AccessTokens;
+using DeviceProvisioning.DeviceRegistry;
+using System.Reflection;
+using System.Web.Http;
+
+namespace DeviceProvisioning
+{
+    public static class AutoFacConfig
+    {
+        public static void Configure()
+        {
+            var builder = new ContainerBuilder();
+            builder.RegisterApiControllers(Assembly.GetExecutingAssembly());
+
+            builder.RegisterInstance<ITokenProvider>(new TokenProvider());
+            builder.RegisterInstance<IDeviceRegistry>(new TableStorageRegistry());
+
+            // Set the dependency resolver to be Autofac.
+            var container = builder.Build();
+            GlobalConfiguration.Configuration.DependencyResolver = new AutofacWebApiDependencyResolver(container);
+        }
+    }
+}

--- a/src/DeviceProvisioning/ProvisioningWebApi/ProvisioningWebApi/App_Start/WebApiConfig.cs
+++ b/src/DeviceProvisioning/ProvisioningWebApi/ProvisioningWebApi/App_Start/WebApiConfig.cs
@@ -1,0 +1,24 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Web.Http;
+
+namespace ProvisioningWebApi
+{
+    public static class WebApiConfig
+    {
+        public static void Register(HttpConfiguration config)
+        {
+            // Web API configuration and services
+
+            // Web API routes
+            config.MapHttpAttributeRoutes();
+
+            config.Routes.MapHttpRoute(
+                name: "DefaultApi",
+                routeTemplate: "api/{controller}/{id}",
+                defaults: new { id = RouteParameter.Optional }
+            );
+        }
+    }
+}

--- a/src/DeviceProvisioning/ProvisioningWebApi/ProvisioningWebApi/Controllers/ProvisionController.cs
+++ b/src/DeviceProvisioning/ProvisioningWebApi/ProvisioningWebApi/Controllers/ProvisionController.cs
@@ -1,0 +1,54 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using DeviceProvisioning.AccessTokens;
+using DeviceProvisioning.DeviceRegistry;
+using Microsoft.Practices.IoTJourney.DeviceProvisioningModels;
+using System.Threading.Tasks;
+using System.Web.Http;
+
+namespace DeviceProvisioning.Controllers
+{
+    public class ProvisionController : ApiController
+    {
+        ITokenProvider _provisioner;
+        IDeviceRegistry _registry;
+
+        public ProvisionController(ITokenProvider provisioner, IDeviceRegistry registry)
+        {
+            _provisioner = provisioner;
+            _registry = registry;
+        }
+
+        [HttpPost]
+        public async Task<IHttpActionResult> ProvisionDevice([FromBody] Device device)
+        {
+            if (device == null)
+            {
+                return BadRequest("device is null");
+            }
+            if (!ModelState.IsValid)
+            {
+                return BadRequest(ModelState);
+            }
+
+            var info = new DeviceInfo
+            {
+                DeviceId = device.DeviceId,
+                Status = "provisioned"
+            };
+
+            await _registry.AddOrUpdate(info);
+
+            var token = await _provisioner.GetTokenAsync(device.DeviceId);
+            var endpoint = new DeviceEndpoint
+            {
+                Uri = _provisioner.EndpointUri.AbsoluteUri,
+                EventHubName = _provisioner.EventHubName,
+                AccessToken = token
+            };
+
+            return Ok(endpoint);
+        }
+    }
+}

--- a/src/DeviceProvisioning/ProvisioningWebApi/ProvisioningWebApi/DeviceRegistry/IDeviceRegistry.cs
+++ b/src/DeviceProvisioning/ProvisioningWebApi/ProvisioningWebApi/DeviceRegistry/IDeviceRegistry.cs
@@ -1,0 +1,14 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Microsoft.Practices.IoTJourney.DeviceProvisioningModels;
+using System.Threading.Tasks;
+
+namespace DeviceProvisioning.DeviceRegistry
+{
+    public interface IDeviceRegistry
+    {
+        Task<bool> AddOrUpdate(DeviceInfo info);
+        Task<DeviceInfo> Find(string id);
+    }
+}

--- a/src/DeviceProvisioning/ProvisioningWebApi/ProvisioningWebApi/DeviceRegistry/TableStorageRegistry.cs
+++ b/src/DeviceProvisioning/ProvisioningWebApi/ProvisioningWebApi/DeviceRegistry/TableStorageRegistry.cs
@@ -1,0 +1,81 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Microsoft.Practices.IoTJourney;
+using Microsoft.Practices.IoTJourney.DeviceProvisioningModels;
+using Microsoft.WindowsAzure.Storage;
+using Microsoft.WindowsAzure.Storage.Table;
+using System.Threading.Tasks;
+
+namespace DeviceProvisioning.DeviceRegistry
+{
+    public class TableStorageRegistry : IDeviceRegistry
+    {
+        const string TableName = "devices";
+
+        // Translate betweeen DeviceInfo objects and table storage entities.
+        class DeviceInfoEntity : TableEntity
+        {
+            public DeviceInfoEntity(DeviceInfo deviceInfo)
+            {
+                this.PartitionKey = deviceInfo.DeviceId;
+                this.RowKey = deviceInfo.DeviceId;
+                this.Status = deviceInfo.Status;
+                if (deviceInfo.Metadata != null)
+                {
+                    this.Building = deviceInfo.Metadata.Building;
+                    this.Room = deviceInfo.Metadata.Room;
+                }
+            }
+
+            public string Status { get; set; }
+            public int Building { get; set; }
+            public int Room { get; set; }
+
+            public DeviceInfo ToDeviceInfo()
+            {
+                return new DeviceInfo
+                {
+                    DeviceId = this.RowKey,
+                    Metadata = new DeviceMetadata { Building = this.Building, Room = this.Room },
+                    Status = this.Status
+                };
+            }
+
+        }
+
+        CloudTableClient _client;
+        CloudTable _table;
+
+        public TableStorageRegistry()
+        {
+            var storageConnectionString = ConfigurationHelper.GetConfigValue<string>("StorageConnectionString");
+            var storageClient = CloudStorageAccount.Parse(storageConnectionString);
+            _client = storageClient.CreateCloudTableClient();
+            _table = _client.GetTableReference(TableName);
+            _table.CreateIfNotExists();
+        }
+
+        public Task<bool> AddOrUpdate(DeviceInfo info)
+        {
+            var entity = new DeviceInfoEntity(info);
+            _table.Execute(TableOperation.InsertOrReplace(entity));
+            return Task.FromResult(true);
+        }
+
+        public System.Threading.Tasks.Task<DeviceInfo> Find(string id)
+        {
+            TableOperation retrieveOperation = TableOperation.Retrieve<DeviceInfoEntity>(id, id);
+            TableResult retrievedResult = _table.Execute(retrieveOperation);
+
+            var result = retrievedResult.Result as DeviceInfoEntity;
+
+            DeviceInfo info = null;
+            if (result != null)
+            {
+                info = result.ToDeviceInfo();
+            }
+            return Task.FromResult(info);
+        }
+    }
+}

--- a/src/DeviceProvisioning/ProvisioningWebApi/ProvisioningWebApi/Global.asax
+++ b/src/DeviceProvisioning/ProvisioningWebApi/ProvisioningWebApi/Global.asax
@@ -1,0 +1,1 @@
+﻿<%@ Application Codebehind="Global.asax.cs" Inherits="ProvisioningWebApi.WebApiApplication" Language="C#" %>

--- a/src/DeviceProvisioning/ProvisioningWebApi/ProvisioningWebApi/Global.asax.cs
+++ b/src/DeviceProvisioning/ProvisioningWebApi/ProvisioningWebApi/Global.asax.cs
@@ -1,0 +1,22 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using DeviceProvisioning;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Web;
+using System.Web.Http;
+using System.Web.Routing;
+
+namespace ProvisioningWebApi
+{
+    public class WebApiApplication : System.Web.HttpApplication
+    {
+        protected void Application_Start()
+        {
+            AutoFacConfig.Configure();
+            GlobalConfiguration.Configure(WebApiConfig.Register);
+        }
+    }
+}

--- a/src/DeviceProvisioning/ProvisioningWebApi/ProvisioningWebApi/Properties/AssemblyInfo.cs
+++ b/src/DeviceProvisioning/ProvisioningWebApi/ProvisioningWebApi/Properties/AssemblyInfo.cs
@@ -1,0 +1,35 @@
+﻿using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+// General Information about an assembly is controlled through the following 
+// set of attributes. Change these attribute values to modify the information
+// associated with an assembly.
+[assembly: AssemblyTitle("ProvisioningWebApi")]
+[assembly: AssemblyDescription("")]
+[assembly: AssemblyConfiguration("")]
+[assembly: AssemblyCompany("")]
+[assembly: AssemblyProduct("ProvisioningWebApi")]
+[assembly: AssemblyCopyright("Copyright ©  2015")]
+[assembly: AssemblyTrademark("")]
+[assembly: AssemblyCulture("")]
+
+// Setting ComVisible to false makes the types in this assembly not visible 
+// to COM components.  If you need to access a type in this assembly from 
+// COM, set the ComVisible attribute to true on that type.
+[assembly: ComVisible(false)]
+
+// The following GUID is for the ID of the typelib if this project is exposed to COM
+[assembly: Guid("c75df32c-16cb-41ff-bf2c-015cac05bc12")]
+
+// Version information for an assembly consists of the following four values:
+//
+//      Major Version
+//      Minor Version 
+//      Build Number
+//      Revision
+//
+// You can specify all the values or you can default the Revision and Build Numbers 
+// by using the '*' as shown below:
+[assembly: AssemblyVersion("1.0.0.0")]
+[assembly: AssemblyFileVersion("1.0.0.0")]

--- a/src/DeviceProvisioning/ProvisioningWebApi/ProvisioningWebApi/ProvisioningWebApi.csproj
+++ b/src/DeviceProvisioning/ProvisioningWebApi/ProvisioningWebApi/ProvisioningWebApi.csproj
@@ -1,0 +1,179 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProductVersion>
+    </ProductVersion>
+    <SchemaVersion>2.0</SchemaVersion>
+    <ProjectGuid>{929CBB8F-CFE3-4A2C-8F89-C7FE63080400}</ProjectGuid>
+    <ProjectTypeGuids>{349c5851-65df-11da-9384-00065b846f21};{fae04ec0-301f-11d3-bf4b-00c04f79efbc}</ProjectTypeGuids>
+    <OutputType>Library</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <RootNamespace>ProvisioningWebApi</RootNamespace>
+    <AssemblyName>ProvisioningWebApi</AssemblyName>
+    <TargetFrameworkVersion>v4.5.1</TargetFrameworkVersion>
+    <UseIISExpress>true</UseIISExpress>
+    <IISExpressSSLPort />
+    <IISExpressAnonymousAuthentication />
+    <IISExpressWindowsAuthentication />
+    <IISExpressUseClassicPipelineMode />
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>bin\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="Autofac">
+      <HintPath>..\..\..\packages\Autofac.3.5.2\lib\net40\Autofac.dll</HintPath>
+    </Reference>
+    <Reference Include="Autofac.Integration.WebApi">
+      <HintPath>..\..\..\packages\Autofac.WebApi2.3.4.0\lib\net45\Autofac.Integration.WebApi.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.CSharp" />
+    <Reference Include="Microsoft.Data.Edm, Version=5.6.4.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <SpecificVersion>False</SpecificVersion>
+      <HintPath>..\..\..\packages\Microsoft.Data.Edm.5.6.4\lib\net40\Microsoft.Data.Edm.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.Data.OData, Version=5.6.4.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <SpecificVersion>False</SpecificVersion>
+      <HintPath>..\..\..\packages\Microsoft.Data.OData.5.6.4\lib\net40\Microsoft.Data.OData.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.Data.Services.Client, Version=5.6.4.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <SpecificVersion>False</SpecificVersion>
+      <HintPath>..\..\..\packages\Microsoft.Data.Services.Client.5.6.4\lib\net40\Microsoft.Data.Services.Client.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.ServiceBus, Version=2.7.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <SpecificVersion>False</SpecificVersion>
+      <HintPath>..\..\..\packages\WindowsAzure.ServiceBus.2.7.2\lib\net40-full\Microsoft.ServiceBus.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.WindowsAzure.Configuration">
+      <HintPath>..\..\..\packages\Microsoft.WindowsAzure.ConfigurationManager.3.1.0\lib\net40\Microsoft.WindowsAzure.Configuration.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.WindowsAzure.Storage, Version=4.3.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <SpecificVersion>False</SpecificVersion>
+      <HintPath>..\..\..\packages\WindowsAzure.Storage.4.3.0\lib\net40\Microsoft.WindowsAzure.Storage.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Net.Http" />
+    <Reference Include="System.Net.Http.Formatting, Version=5.2.3.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <SpecificVersion>False</SpecificVersion>
+      <HintPath>..\..\..\packages\Microsoft.AspNet.WebApi.Client.5.2.3\lib\net45\System.Net.Http.Formatting.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Runtime.Serialization" />
+    <Reference Include="System.ServiceModel" />
+    <Reference Include="System.Spatial, Version=5.6.4.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <SpecificVersion>False</SpecificVersion>
+      <HintPath>..\..\..\packages\System.Spatial.5.6.4\lib\net40\System.Spatial.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Web.DynamicData" />
+    <Reference Include="System.Web.Entity" />
+    <Reference Include="System.Web.ApplicationServices" />
+    <Reference Include="System.ComponentModel.DataAnnotations" />
+    <Reference Include="System" />
+    <Reference Include="System.Data" />
+    <Reference Include="System.Core" />
+    <Reference Include="System.Data.DataSetExtensions" />
+    <Reference Include="System.Web.Extensions" />
+    <Reference Include="System.Web.Http, Version=5.2.3.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <SpecificVersion>False</SpecificVersion>
+      <HintPath>..\..\..\packages\Microsoft.AspNet.WebApi.Core.5.2.3\lib\net45\System.Web.Http.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Web.Http.WebHost, Version=5.2.3.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <SpecificVersion>False</SpecificVersion>
+      <HintPath>..\..\..\packages\Microsoft.AspNet.WebApi.WebHost.5.2.3\lib\net45\System.Web.Http.WebHost.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Xml.Linq" />
+    <Reference Include="System.Drawing" />
+    <Reference Include="System.Web" />
+    <Reference Include="System.Xml" />
+    <Reference Include="System.Configuration" />
+    <Reference Include="System.Web.Services" />
+    <Reference Include="System.EnterpriseServices" />
+  </ItemGroup>
+  <ItemGroup>
+    <Reference Include="Newtonsoft.Json">
+      <HintPath>..\..\..\packages\Newtonsoft.Json.6.0.4\lib\net45\Newtonsoft.Json.dll</HintPath>
+    </Reference>
+  </ItemGroup>
+  <ItemGroup>
+    <Content Include="Global.asax" />
+    <Content Include="Web.config" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="App_Start\AutoFacConfig.cs" />
+    <Compile Include="App_Start\WebApiConfig.cs" />
+    <Compile Include="Controllers\ProvisionController.cs" />
+    <Compile Include="DeviceRegistry\IDeviceRegistry.cs" />
+    <Compile Include="DeviceRegistry\TableStorageRegistry.cs" />
+    <Compile Include="Global.asax.cs">
+      <DependentUpon>Global.asax</DependentUpon>
+    </Compile>
+    <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="TokenProvider\ITokenProvider.cs" />
+    <Compile Include="TokenProvider\TokenProvider.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <Content Include="packages.config" />
+    <None Include="Web.Debug.config">
+      <DependentUpon>Web.config</DependentUpon>
+    </None>
+    <None Include="Web.Release.config">
+      <DependentUpon>Web.config</DependentUpon>
+    </None>
+  </ItemGroup>
+  <ItemGroup>
+    <Folder Include="App_Data\" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\..\Shared\Core\Core.csproj">
+      <Project>{b3657b80-640f-4d72-885e-e9f9729bac18}</Project>
+      <Name>Core</Name>
+    </ProjectReference>
+  </ItemGroup>
+  <PropertyGroup>
+    <VisualStudioVersion Condition="'$(VisualStudioVersion)' == ''">10.0</VisualStudioVersion>
+    <VSToolsPath Condition="'$(VSToolsPath)' == ''">$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)</VSToolsPath>
+  </PropertyGroup>
+  <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
+  <Import Project="$(VSToolsPath)\WebApplications\Microsoft.WebApplication.targets" Condition="'$(VSToolsPath)' != ''" />
+  <Import Project="$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v10.0\WebApplications\Microsoft.WebApplication.targets" Condition="false" />
+  <ProjectExtensions>
+    <VisualStudio>
+      <FlavorProperties GUID="{349c5851-65df-11da-9384-00065b846f21}">
+        <WebProjectProperties>
+          <UseIIS>True</UseIIS>
+          <AutoAssignPort>True</AutoAssignPort>
+          <DevelopmentServerPort>63939</DevelopmentServerPort>
+          <DevelopmentServerVPath>/</DevelopmentServerVPath>
+          <IISUrl>http://localhost:63900/</IISUrl>
+          <NTLMAuthentication>False</NTLMAuthentication>
+          <UseCustomServer>False</UseCustomServer>
+          <CustomServerUrl>
+          </CustomServerUrl>
+          <SaveServerSettingsInUserFile>False</SaveServerSettingsInUserFile>
+        </WebProjectProperties>
+      </FlavorProperties>
+    </VisualStudio>
+  </ProjectExtensions>
+  <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
+       Other similar extension points exist, see Microsoft.Common.targets.
+  <Target Name="BeforeBuild">
+  </Target>
+  <Target Name="AfterBuild">
+  </Target>
+  -->
+</Project>

--- a/src/DeviceProvisioning/ProvisioningWebApi/ProvisioningWebApi/TokenProvider/ITokenProvider.cs
+++ b/src/DeviceProvisioning/ProvisioningWebApi/ProvisioningWebApi/TokenProvider/ITokenProvider.cs
@@ -1,0 +1,15 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Threading.Tasks;
+
+namespace DeviceProvisioning.AccessTokens
+{
+    public interface ITokenProvider
+    {
+        Uri EndpointUri { get; }
+        string EventHubName { get; }
+        Task<string> GetTokenAsync(string DeviceId);
+    }
+}

--- a/src/DeviceProvisioning/ProvisioningWebApi/ProvisioningWebApi/TokenProvider/TokenProvider.cs
+++ b/src/DeviceProvisioning/ProvisioningWebApi/ProvisioningWebApi/TokenProvider/TokenProvider.cs
@@ -1,0 +1,49 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Microsoft.Practices.IoTJourney;
+using Microsoft.ServiceBus;
+using System;
+using System.Threading.Tasks;
+
+namespace DeviceProvisioning.AccessTokens
+{
+    public class TokenProvider : ITokenProvider
+    {
+        private string EventHubPrimaryKey;
+        private string EventHubNamespace;
+        private string EventHubSasKeyName;
+        private double EventHubTokenLifetimeDays = 10;
+
+        public TokenProvider()
+        {
+            EventHubPrimaryKey = ConfigurationHelper.GetConfigValue<string>("EventHubPrimaryKey");
+            EventHubNamespace = ConfigurationHelper.GetConfigValue<string>("EventHubNamespace");
+            EventHubName = ConfigurationHelper.GetConfigValue<string>("EventHubName");
+            EventHubSasKeyName = ConfigurationHelper.GetConfigValue<string>("EventHubSasKeyName");
+            EndpointUri = new Uri(String.Format("https://{0}.servicebus.windows.net", EventHubNamespace));
+        }
+
+        public Uri EndpointUri { get; private set; }
+
+        public string EventHubName { get; private set; }
+
+        public Task<string> GetTokenAsync(string DeviceId)
+        {
+            var endpoint = ServiceBusEnvironment.CreateServiceUri("sb", EventHubNamespace, string.Empty);
+
+            // Generate token for the device.
+            string deviceToken = SharedAccessSignatureTokenProvider.GetPublisherSharedAccessSignature
+            (
+                endpoint,
+                EventHubName,
+                DeviceId,
+                EventHubSasKeyName,
+                EventHubPrimaryKey,
+                TimeSpan.FromDays(EventHubTokenLifetimeDays)
+            );
+
+            return Task.FromResult(deviceToken);
+        }
+    }
+}

--- a/src/DeviceProvisioning/ProvisioningWebApi/ProvisioningWebApi/Web.Debug.config
+++ b/src/DeviceProvisioning/ProvisioningWebApi/ProvisioningWebApi/Web.Debug.config
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+<!-- For more information on using web.config transformation visit http://go.microsoft.com/fwlink/?LinkId=125889 -->
+
+<configuration xmlns:xdt="http://schemas.microsoft.com/XML-Document-Transform">
+  <!--
+    In the example below, the "SetAttributes" transform will change the value of 
+    "connectionString" to use "ReleaseSQLServer" only when the "Match" locator 
+    finds an attribute "name" that has a value of "MyDB".
+    
+    <connectionStrings>
+      <add name="MyDB" 
+        connectionString="Data Source=ReleaseSQLServer;Initial Catalog=MyReleaseDB;Integrated Security=True" 
+        xdt:Transform="SetAttributes" xdt:Locator="Match(name)"/>
+    </connectionStrings>
+  -->
+  <system.web>
+    <!--
+      In the example below, the "Replace" transform will replace the entire 
+      <customErrors> section of your web.config file.
+      Note that because there is only one customErrors section under the 
+      <system.web> node, there is no need to use the "xdt:Locator" attribute.
+      
+      <customErrors defaultRedirect="GenericError.htm"
+        mode="RemoteOnly" xdt:Transform="Replace">
+        <error statusCode="500" redirect="InternalError.htm"/>
+      </customErrors>
+    -->
+  </system.web>
+</configuration>

--- a/src/DeviceProvisioning/ProvisioningWebApi/ProvisioningWebApi/Web.Release.config
+++ b/src/DeviceProvisioning/ProvisioningWebApi/ProvisioningWebApi/Web.Release.config
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+<!-- For more information on using web.config transformation visit http://go.microsoft.com/fwlink/?LinkId=125889 -->
+
+<configuration xmlns:xdt="http://schemas.microsoft.com/XML-Document-Transform">
+  <!--
+    In the example below, the "SetAttributes" transform will change the value of 
+    "connectionString" to use "ReleaseSQLServer" only when the "Match" locator 
+    finds an attribute "name" that has a value of "MyDB".
+    
+    <connectionStrings>
+      <add name="MyDB" 
+        connectionString="Data Source=ReleaseSQLServer;Initial Catalog=MyReleaseDB;Integrated Security=True" 
+        xdt:Transform="SetAttributes" xdt:Locator="Match(name)"/>
+    </connectionStrings>
+  -->
+  <system.web>
+    <compilation xdt:Transform="RemoveAttributes(debug)" />
+    <!--
+      In the example below, the "Replace" transform will replace the entire 
+      <customErrors> section of your web.config file.
+      Note that because there is only one customErrors section under the 
+      <system.web> node, there is no need to use the "xdt:Locator" attribute.
+      
+      <customErrors defaultRedirect="GenericError.htm"
+        mode="RemoteOnly" xdt:Transform="Replace">
+        <error statusCode="500" redirect="InternalError.htm"/>
+      </customErrors>
+    -->
+  </system.web>
+</configuration>

--- a/src/DeviceProvisioning/ProvisioningWebApi/ProvisioningWebApi/Web.config
+++ b/src/DeviceProvisioning/ProvisioningWebApi/ProvisioningWebApi/Web.config
@@ -1,0 +1,118 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<!--
+  For more information on how to configure your ASP.NET application, please visit
+  http://go.microsoft.com/fwlink/?LinkId=301879
+  -->
+<configuration>
+  <appSettings file="..\settings.config">
+    <!-- See http://www.asp.net/identity/overview/features-api/best-practices-for-deploying-passwords-and-other-sensitive-data-to-aspnet-and-azure -->
+    <add key="Microsoft.ServiceBus.ConnectionString" value="Endpoint=sb://[your namespace].servicebus.windows.net;SharedAccessKeyName=RootManageSharedAccessKey;SharedAccessKey=[your secret]" />
+  </appSettings>
+  <system.web>
+    <compilation debug="true" targetFramework="4.5.1" />
+    <httpRuntime targetFramework="4.5.1" />
+  </system.web>
+  
+  <runtime>
+    <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
+      <dependentAssembly>
+        <assemblyIdentity name="Microsoft.Owin" publicKeyToken="31bf3856ad364e35" />
+        <bindingRedirect oldVersion="1.0.0.0-3.0.0.0" newVersion="3.0.0.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="Microsoft.Owin.Security.OAuth" publicKeyToken="31bf3856ad364e35" />
+        <bindingRedirect oldVersion="1.0.0.0-3.0.0.0" newVersion="3.0.0.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="Microsoft.Owin.Security.Cookies" publicKeyToken="31bf3856ad364e35" />
+        <bindingRedirect oldVersion="1.0.0.0-3.0.0.0" newVersion="3.0.0.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="Microsoft.Owin.Security" publicKeyToken="31bf3856ad364e35" />
+        <bindingRedirect oldVersion="1.0.0.0-3.0.0.0" newVersion="3.0.0.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="Newtonsoft.Json" culture="neutral" publicKeyToken="30ad4fe6b2a6aeed" />
+        <bindingRedirect oldVersion="0.0.0.0-6.0.0.0" newVersion="6.0.0.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.Web.Helpers" publicKeyToken="31bf3856ad364e35" />
+        <bindingRedirect oldVersion="1.0.0.0-3.0.0.0" newVersion="3.0.0.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.Web.Mvc" publicKeyToken="31bf3856ad364e35" />
+        <bindingRedirect oldVersion="1.0.0.0-5.2.2.0" newVersion="5.2.2.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.Web.Optimization" publicKeyToken="31bf3856ad364e35" />
+        <bindingRedirect oldVersion="1.0.0.0-1.1.0.0" newVersion="1.1.0.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.Web.WebPages" publicKeyToken="31bf3856ad364e35" />
+        <bindingRedirect oldVersion="1.0.0.0-3.0.0.0" newVersion="3.0.0.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="WebGrease" publicKeyToken="31bf3856ad364e35" />
+        <bindingRedirect oldVersion="1.0.0.0-1.5.2.14234" newVersion="1.5.2.14234" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="Microsoft.Data.Edm" publicKeyToken="31bf3856ad364e35" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-5.6.4.0" newVersion="5.6.4.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="Microsoft.Data.Services.Client" publicKeyToken="31bf3856ad364e35" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-5.6.4.0" newVersion="5.6.4.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="Microsoft.Data.OData" publicKeyToken="31bf3856ad364e35" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-5.6.4.0" newVersion="5.6.4.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.Web.Http" publicKeyToken="31bf3856ad364e35" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-5.2.3.0" newVersion="5.2.3.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.Net.Http.Formatting" publicKeyToken="31bf3856ad364e35" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-5.2.3.0" newVersion="5.2.3.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.Spatial" publicKeyToken="31bf3856ad364e35" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-5.6.2.0" newVersion="5.6.2.0" />
+      </dependentAssembly>
+    </assemblyBinding>
+  </runtime>
+<system.webServer>
+    <handlers>
+      <remove name="ExtensionlessUrlHandler-Integrated-4.0" />
+      <remove name="OPTIONSVerbHandler" />
+      <remove name="TRACEVerbHandler" />
+      <add name="ExtensionlessUrlHandler-Integrated-4.0" path="*." verb="*" type="System.Web.Handlers.TransferRequestHandler" preCondition="integratedMode,runtimeVersionv4.0" />
+    </handlers>
+  </system.webServer>
+<system.serviceModel>
+<extensions>
+<!-- In this extension section we are introducing all known service bus extensions. User can remove the ones they don't need. -->
+<behaviorExtensions>
+<add name="connectionStatusBehavior" type="Microsoft.ServiceBus.Configuration.ConnectionStatusElement, Microsoft.ServiceBus, Culture=neutral, PublicKeyToken=31bf3856ad364e35" />
+<add name="transportClientEndpointBehavior" type="Microsoft.ServiceBus.Configuration.TransportClientEndpointBehaviorElement, Microsoft.ServiceBus, Culture=neutral, PublicKeyToken=31bf3856ad364e35" />
+<add name="serviceRegistrySettings" type="Microsoft.ServiceBus.Configuration.ServiceRegistrySettingsElement, Microsoft.ServiceBus, Culture=neutral, PublicKeyToken=31bf3856ad364e35" />
+</behaviorExtensions>
+<bindingElementExtensions>
+<add name="netMessagingTransport" type="Microsoft.ServiceBus.Messaging.Configuration.NetMessagingTransportExtensionElement, Microsoft.ServiceBus,  Culture=neutral, PublicKeyToken=31bf3856ad364e35" />
+<add name="tcpRelayTransport" type="Microsoft.ServiceBus.Configuration.TcpRelayTransportElement, Microsoft.ServiceBus, Culture=neutral, PublicKeyToken=31bf3856ad364e35" />
+<add name="httpRelayTransport" type="Microsoft.ServiceBus.Configuration.HttpRelayTransportElement, Microsoft.ServiceBus, Culture=neutral, PublicKeyToken=31bf3856ad364e35" />
+<add name="httpsRelayTransport" type="Microsoft.ServiceBus.Configuration.HttpsRelayTransportElement, Microsoft.ServiceBus, Culture=neutral, PublicKeyToken=31bf3856ad364e35" />
+<add name="onewayRelayTransport" type="Microsoft.ServiceBus.Configuration.RelayedOnewayTransportElement, Microsoft.ServiceBus, Culture=neutral, PublicKeyToken=31bf3856ad364e35" />
+</bindingElementExtensions>
+<bindingExtensions>
+<add name="basicHttpRelayBinding" type="Microsoft.ServiceBus.Configuration.BasicHttpRelayBindingCollectionElement, Microsoft.ServiceBus, Culture=neutral, PublicKeyToken=31bf3856ad364e35" />
+<add name="webHttpRelayBinding" type="Microsoft.ServiceBus.Configuration.WebHttpRelayBindingCollectionElement, Microsoft.ServiceBus, Culture=neutral, PublicKeyToken=31bf3856ad364e35" />
+<add name="ws2007HttpRelayBinding" type="Microsoft.ServiceBus.Configuration.WS2007HttpRelayBindingCollectionElement, Microsoft.ServiceBus, Culture=neutral, PublicKeyToken=31bf3856ad364e35" />
+<add name="netTcpRelayBinding" type="Microsoft.ServiceBus.Configuration.NetTcpRelayBindingCollectionElement, Microsoft.ServiceBus, Culture=neutral, PublicKeyToken=31bf3856ad364e35" />
+<add name="netOnewayRelayBinding" type="Microsoft.ServiceBus.Configuration.NetOnewayRelayBindingCollectionElement, Microsoft.ServiceBus, Culture=neutral, PublicKeyToken=31bf3856ad364e35" />
+<add name="netEventRelayBinding" type="Microsoft.ServiceBus.Configuration.NetEventRelayBindingCollectionElement, Microsoft.ServiceBus, Culture=neutral, PublicKeyToken=31bf3856ad364e35" />
+<add name="netMessagingBinding" type="Microsoft.ServiceBus.Messaging.Configuration.NetMessagingBindingCollectionElement, Microsoft.ServiceBus, Culture=neutral, PublicKeyToken=31bf3856ad364e35" />
+</bindingExtensions>
+</extensions>
+</system.serviceModel>
+</configuration>

--- a/src/DeviceProvisioning/ProvisioningWebApi/ProvisioningWebApi/packages.config
+++ b/src/DeviceProvisioning/ProvisioningWebApi/ProvisioningWebApi/packages.config
@@ -1,0 +1,17 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="Autofac" version="3.5.2" targetFramework="net451" />
+  <package id="Autofac.WebApi2" version="3.4.0" targetFramework="net451" />
+  <package id="Microsoft.AspNet.WebApi" version="5.2.3" targetFramework="net451" />
+  <package id="Microsoft.AspNet.WebApi.Client" version="5.2.3" targetFramework="net451" />
+  <package id="Microsoft.AspNet.WebApi.Core" version="5.2.3" targetFramework="net451" />
+  <package id="Microsoft.AspNet.WebApi.WebHost" version="5.2.3" targetFramework="net451" />
+  <package id="Microsoft.Data.Edm" version="5.6.4" targetFramework="net451" />
+  <package id="Microsoft.Data.OData" version="5.6.4" targetFramework="net451" />
+  <package id="Microsoft.Data.Services.Client" version="5.6.4" targetFramework="net451" />
+  <package id="Microsoft.WindowsAzure.ConfigurationManager" version="3.1.0" targetFramework="net451" />
+  <package id="Newtonsoft.Json" version="6.0.4" targetFramework="net451" />
+  <package id="System.Spatial" version="5.6.4" targetFramework="net451" />
+  <package id="WindowsAzure.ServiceBus" version="2.7.2" targetFramework="net451" />
+  <package id="WindowsAzure.Storage" version="4.3.0" targetFramework="net451" />
+</packages>

--- a/src/DeviceProvisioning/ProvisioningWebApi/ProvisioningWebApi/settings.template.config
+++ b/src/DeviceProvisioning/ProvisioningWebApi/ProvisioningWebApi/settings.template.config
@@ -1,0 +1,9 @@
+﻿<?xml version="1.0"?>
+  <appSettings>
+    <add key="EventHubPrimaryKey" value="[Event hub primary key]"/>
+    <add key="EventHubNamespace" value="[Event hub namespace]"/>
+    <add key="EventHubName" value="[Event hub name]"/>
+    <add key="EventHubSasKeyName" value="[Event hub policy name]"/>
+    <add key="StorageConnectionString" value="[Azure storage connection string]"/>
+  </appSettings>
+

--- a/src/DeviceProvisioning/ProvisioningWebApi/nuget.config
+++ b/src/DeviceProvisioning/ProvisioningWebApi/nuget.config
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <config>
+    <add key="repositorypath" value="..\..\packages" />
+  </config>
+</configuration>

--- a/src/Shared/Core/Core.csproj
+++ b/src/Shared/Core/Core.csproj
@@ -69,6 +69,7 @@
       <Private>True</Private>
     </Reference>
     <Reference Include="System" />
+    <Reference Include="System.ComponentModel.DataAnnotations" />
     <Reference Include="System.Configuration" />
     <Reference Include="System.Configuration.Install" />
     <Reference Include="System.Core" />
@@ -89,6 +90,10 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="ConfigurationHelper.cs" />
+    <Compile Include="DeviceProvisioningModels\Device.cs" />
+    <Compile Include="DeviceProvisioningModels\DeviceEndpoint.cs" />
+    <Compile Include="DeviceProvisioningModels\DeviceInfo.cs" />
+    <Compile Include="DeviceProvisioningModels\DeviceMetadata.cs" />
     <Compile Include="Guard.cs" />
     <Compile Include="Logging\ScenarioSimulatorEventSource.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />

--- a/src/Shared/Core/DeviceProvisioningModels/Device.cs
+++ b/src/Shared/Core/DeviceProvisioningModels/Device.cs
@@ -1,0 +1,13 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.ComponentModel.DataAnnotations;
+
+namespace Microsoft.Practices.IoTJourney.DeviceProvisioningModels
+{
+    public class Device
+    {
+        [Required]
+        public string DeviceId { get; set; }
+    }
+}

--- a/src/Shared/Core/DeviceProvisioningModels/DeviceEndpoint.cs
+++ b/src/Shared/Core/DeviceProvisioningModels/DeviceEndpoint.cs
@@ -1,0 +1,14 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+
+namespace Microsoft.Practices.IoTJourney.DeviceProvisioningModels
+{
+    public class DeviceEndpoint
+    {
+        public string Uri { get; set; }
+        public string EventHubName { get; set; }
+        public string AccessToken { get; set; }
+    }
+}

--- a/src/Shared/Core/DeviceProvisioningModels/DeviceInfo.cs
+++ b/src/Shared/Core/DeviceProvisioningModels/DeviceInfo.cs
@@ -1,0 +1,12 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Microsoft.Practices.IoTJourney.DeviceProvisioningModels
+{
+    public class DeviceInfo
+    {
+        public string DeviceId { get; set; }
+        public string Status { get; set; }
+        public DeviceMetadata Metadata { get; set; }
+    }
+}

--- a/src/Shared/Core/DeviceProvisioningModels/DeviceMetadata.cs
+++ b/src/Shared/Core/DeviceProvisioningModels/DeviceMetadata.cs
@@ -1,0 +1,11 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Microsoft.Practices.IoTJourney.DeviceProvisioningModels
+{
+    public class DeviceMetadata
+    {
+        public int Building { get; set; }
+        public int Room { get; set; }
+    }
+}


### PR DESCRIPTION
Adds a Web API project for device provisioning. Right now there is a single "provision" API. This addresses #202, and is also the foundation for the other REST APIs described in #201.

Note: A couple of things not implemented yet
- Event tracing
- Azure provisioning (PS script)

For the device registry, I'm currently writing the device metadata to Azure table storage, mainly for simplicity. However it's implemented as a service, so it will be easy to replace that piece. e.g., to use DocumentDB instead.

connects to #202
