### PR TITLE
Larry/fix faultytiming

### DIFF
--- a/src/Shared/Core/Core.csproj
+++ b/src/Shared/Core/Core.csproj
@@ -94,6 +94,7 @@
     <Compile Include="DeviceProvisioningModels\DeviceEndpoint.cs" />
     <Compile Include="DeviceProvisioningModels\DeviceInfo.cs" />
     <Compile Include="DeviceProvisioningModels\DeviceMetadata.cs" />
+    <Compile Include="Extensions.cs" />
     <Compile Include="Guard.cs" />
     <Compile Include="Logging\ScenarioSimulatorEventSource.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />

--- a/src/Shared/Core/Extensions.cs
+++ b/src/Shared/Core/Extensions.cs
@@ -1,0 +1,15 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+
+namespace Microsoft.Practices.IoTJourney
+{
+    public static class Extensions
+    {
+        public static TimeSpan Multiply(this TimeSpan timeSpan, double factor)
+        {
+            return TimeSpan.FromTicks((long)(timeSpan.Ticks * factor));
+        }
+    }
+}


### PR DESCRIPTION
connects to #177 

In fixing this issue, it helped us define bit more to understand and validate our accuracy in our sending per seconds.  To help to quantify our timing accuracy added & fix unit tests.

In going through our timing implementation. It's worth going a bit deeper to understand the moving parts that this PR should fix.  Since it's a major control in our simulation coordination for sending events from the devices.

And always looking for improvements. 

Device.cs contains our device model and has a message loop in **RunSimulationAsync** method. The loop is  emitting message(s) at certain frequency to the event hub. In this case we are only sending 1 message type at time.  And is running the code for our Task.Delay(loopfrequency).  Our loopFrequency set's the frequency of when we are going to check our elapsed time.  It's set to 300 ms. 

The issue was improving our accuracy because the imprecision that occurred in  measuring our elapse time with the our desired frequency.  Via testing found we could lose up to 200 to 299 ms. Per loop.


The solution was to calculate the remainder time, which is the we were off from the frequency we wanted.  The next loop would start at this remainder.  This was fixed in the ResetElaspedTime in Entry.cs

Entry.cs which handles the timing for its message for a device with the following 3 APIs:

- public void UpdateElapsedTime(TimeSpan elapsed)
- public bool ShouldSendEvent()
- public double ResetElapsedTime()

Adding the remainder meant we had to handle the initial condition where we get a high negative remainder it helped us go from an estimated 30 % accuracy to a measurable 85 to 95%. Depends on your sampling frequency.  One of the tradeoff's is CPU.  

So this also starts a way for us to measure and tune the simulator throughput performance of our system.  

The Unit test are in the ScenarioSimulator.Tests in WhenTrackingEventsToSend:

- public void JitterShouldOscillateAroundSendingFrequency()
- public void ShouldNotExpectToSendAfterReset()

The  JitterShouldOscillateAroundSendingFrequency() is the method that works on quantifying the accuracy.

