### PR TITLE
Add web API for device registry/device metadata

### DIFF
--- a/src/DeviceProvisioning/ProvisioningWebApi/ProvisioningWebApi.Tests/ProvisioningWebApi.Tests.csproj
+++ b/src/DeviceProvisioning/ProvisioningWebApi/ProvisioningWebApi.Tests/ProvisioningWebApi.Tests.csproj
@@ -70,8 +70,10 @@
     </Reference>
   </ItemGroup>
   <ItemGroup>
-    <Compile Include="GivenAProvisionController.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="WhenGettingDeviceMetadata.cs" />
+    <Compile Include="WhenProvisioning.cs" />
+    <Compile Include="WhenPuttingDeviceMetadata.cs" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\..\Shared\Core\Core.csproj">

--- a/src/DeviceProvisioning/ProvisioningWebApi/ProvisioningWebApi.Tests/WhenGettingDeviceMetadata.cs
+++ b/src/DeviceProvisioning/ProvisioningWebApi/ProvisioningWebApi.Tests/WhenGettingDeviceMetadata.cs
@@ -1,0 +1,50 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using DeviceProvisioning.DeviceRegistry;
+using Microsoft.Practices.IoTJourney.DeviceProvisioningModels;
+using Moq;
+using ProvisioningWebApi.Controllers;
+using System.Threading.Tasks;
+using System.Web.Http;
+using System.Web.Http.Results;
+using Xunit;
+
+namespace ProvisioningWebApi.Tests
+{
+    public class WhenGettingDeviceMetadata
+    {
+        private RegistryController _controller; 
+        private Mock<IDeviceRegistry> _registry;
+
+        const string DEVICE_ID = "111";
+
+        public WhenGettingDeviceMetadata()
+        {
+            _registry = new Mock<IDeviceRegistry>();
+
+            _registry.Setup(x => x.FindAsync(DEVICE_ID))
+                .ReturnsAsync(new DeviceInfo { DeviceId = DEVICE_ID });
+
+            _controller = new RegistryController(_registry.Object);
+        }
+
+        [Fact]
+        public async Task IfFoundReturnsOk()
+        {
+
+            IHttpActionResult actionResult = await _controller.GetDeviceMetadata(DEVICE_ID);
+            var contentResult = actionResult as OkNegotiatedContentResult<DeviceInfo>;
+
+            Assert.NotNull(contentResult);
+            Assert.NotNull(contentResult.Content);
+        }
+
+        [Fact]
+        public async Task IfNotFoundReturnsNotFound()
+        {
+            IHttpActionResult actionResult = await _controller.GetDeviceMetadata("NOSUCHDEVICE");
+            Assert.IsType<NotFoundResult>(actionResult);
+        }
+    }
+}

--- a/src/DeviceProvisioning/ProvisioningWebApi/ProvisioningWebApi.Tests/WhenPuttingDeviceMetadata.cs
+++ b/src/DeviceProvisioning/ProvisioningWebApi/ProvisioningWebApi.Tests/WhenPuttingDeviceMetadata.cs
@@ -1,0 +1,71 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using DeviceProvisioning.DeviceRegistry;
+using Microsoft.Practices.IoTJourney.DeviceProvisioningModels;
+using Moq;
+using ProvisioningWebApi.Controllers;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using System.Web.Http;
+using System.Web.Http.Results;
+using Xunit;
+
+namespace ProvisioningWebApi.Tests
+{
+    public class WhenPuttingDeviceMetadata
+    {
+        private RegistryController _controller; 
+        private Mock<IDeviceRegistry> _registry;
+
+        public WhenPuttingDeviceMetadata()
+        {
+
+            _registry = new Mock<IDeviceRegistry>();
+            _registry.Setup(x => x.AddOrUpdateAsync(It.IsAny<DeviceInfo>()))
+                .ReturnsAsync(true);
+
+            _controller = new RegistryController(_registry.Object);
+        }
+
+        [Fact]
+        public async Task NullMetadataReturnsBadRequest()
+        {
+            IHttpActionResult actionResult = await _controller.PutDeviceMetadata("1", null);
+            Assert.IsType<BadRequestErrorMessageResult>(actionResult);
+        }
+
+        [Fact]
+        public async Task NewDeviceReturnsCreated()
+        {
+            string id = "111";
+            var metadata = new DeviceMetadata();
+
+            IHttpActionResult actionResult = await _controller.PutDeviceMetadata(id, metadata);
+            var createdResult = actionResult as CreatedAtRouteNegotiatedContentResult<DeviceInfo>;
+
+            Assert.NotNull(createdResult);
+            Assert.Equal("DefaultApi", createdResult.RouteName);
+            Assert.Equal(id, createdResult.RouteValues["id"]);
+        }
+
+        [Fact]
+        public async Task ExistingDeviceReturnsOk()
+        {
+            string id = "112";
+            var metadata = new DeviceMetadata();
+
+            _registry.Setup(x => x.FindAsync(id))
+                .ReturnsAsync(new DeviceInfo { DeviceId = id });
+
+            IHttpActionResult actionResult = await _controller.PutDeviceMetadata(id, metadata);
+            var contentResult = actionResult as OkNegotiatedContentResult<DeviceInfo>;
+
+            Assert.NotNull(contentResult);
+            Assert.NotNull(contentResult.Content);
+        }
+    }
+}

--- a/src/DeviceProvisioning/ProvisioningWebApi/ProvisioningWebApi/Controllers/RegistryController.cs
+++ b/src/DeviceProvisioning/ProvisioningWebApi/ProvisioningWebApi/Controllers/RegistryController.cs
@@ -1,0 +1,64 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using DeviceProvisioning.DeviceRegistry;
+using Microsoft.Practices.IoTJourney.DeviceProvisioningModels;
+using System.Threading.Tasks;
+using System.Web.Http;
+
+namespace ProvisioningWebApi.Controllers
+{
+    public class RegistryController : ApiController
+    {
+        IDeviceRegistry _registry;
+
+        public RegistryController(IDeviceRegistry registry)
+        {
+            _registry = registry;
+        }
+
+        [HttpGet]
+        public async Task<IHttpActionResult> GetDeviceMetadata(string id)
+        {
+            var info = await _registry.FindAsync(id);
+            if (info == null)
+            {
+                return NotFound();
+            }
+
+            return Ok(info);
+        }
+
+        [HttpPut]
+        public async Task<IHttpActionResult> PutDeviceMetadata(string id, [FromBody] DeviceMetadata metadata)
+        {
+            if (metadata == null)
+            {
+                return BadRequest("metadata is null");
+            }
+            if (!ModelState.IsValid)
+            {
+                return BadRequest(ModelState);
+            }
+
+            DeviceInfo info = await _registry.FindAsync(id);
+            if (info == null)
+            {
+                info = new DeviceInfo 
+                { 
+                    DeviceId = id, 
+                    Status = DeviceStateConstants.RegisteredState,
+                    Metadata = metadata
+                };
+                await _registry.AddOrUpdateAsync(info);
+                return CreatedAtRoute("DefaultApi", new { id = id }, info);
+            }
+            else
+            {
+                info.Metadata = metadata;
+                await _registry.AddOrUpdateAsync(info);
+                return Ok(info);
+            }
+        }
+    }
+}

--- a/src/DeviceProvisioning/ProvisioningWebApi/ProvisioningWebApi/DeviceRegistry/IDeviceRegistry.cs
+++ b/src/DeviceProvisioning/ProvisioningWebApi/ProvisioningWebApi/DeviceRegistry/IDeviceRegistry.cs
@@ -8,7 +8,7 @@ namespace DeviceProvisioning.DeviceRegistry
 {
     public interface IDeviceRegistry
     {
-        Task<bool> AddOrUpdate(DeviceInfo info);
-        Task<DeviceInfo> Find(string id);
+        Task<bool> AddOrUpdateAsync(DeviceInfo info);
+        Task<DeviceInfo> FindAsync(string id);
     }
 }

--- a/src/DeviceProvisioning/ProvisioningWebApi/ProvisioningWebApi/DeviceRegistry/TableStorageRegistry.cs
+++ b/src/DeviceProvisioning/ProvisioningWebApi/ProvisioningWebApi/DeviceRegistry/TableStorageRegistry.cs
@@ -16,6 +16,10 @@ namespace DeviceProvisioning.DeviceRegistry
         // Translate betweeen DeviceInfo objects and table storage entities.
         class DeviceInfoEntity : TableEntity
         {
+            public DeviceInfoEntity()
+            {
+
+            }
             public DeviceInfoEntity(DeviceInfo deviceInfo)
             {
                 this.PartitionKey = deviceInfo.DeviceId;
@@ -56,14 +60,14 @@ namespace DeviceProvisioning.DeviceRegistry
             _table.CreateIfNotExists();
         }
 
-        public Task<bool> AddOrUpdate(DeviceInfo info)
+        public Task<bool> AddOrUpdateAsync(DeviceInfo info)
         {
             var entity = new DeviceInfoEntity(info);
             _table.Execute(TableOperation.InsertOrReplace(entity));
             return Task.FromResult(true);
         }
 
-        public System.Threading.Tasks.Task<DeviceInfo> Find(string id)
+        public System.Threading.Tasks.Task<DeviceInfo> FindAsync(string id)
         {
             TableOperation retrieveOperation = TableOperation.Retrieve<DeviceInfoEntity>(id, id);
             TableResult retrievedResult = _table.Execute(retrieveOperation);

--- a/src/DeviceProvisioning/ProvisioningWebApi/ProvisioningWebApi/ProvisioningWebApi.csproj
+++ b/src/DeviceProvisioning/ProvisioningWebApi/ProvisioningWebApi/ProvisioningWebApi.csproj
@@ -117,6 +117,7 @@
     <Compile Include="App_Start\AutoFacConfig.cs" />
     <Compile Include="App_Start\WebApiConfig.cs" />
     <Compile Include="Controllers\ProvisionController.cs" />
+    <Compile Include="Controllers\RegistryController.cs" />
     <Compile Include="DeviceRegistry\IDeviceRegistry.cs" />
     <Compile Include="DeviceRegistry\TableStorageRegistry.cs" />
     <Compile Include="Global.asax.cs">

--- a/src/DeviceProvisioning/ProvisioningWebApi/ProvisioningWebApi/Web.config
+++ b/src/DeviceProvisioning/ProvisioningWebApi/ProvisioningWebApi/Web.config
@@ -4,9 +4,8 @@
   http://go.microsoft.com/fwlink/?LinkId=301879
   -->
 <configuration>
-  <appSettings file="..\settings.config">
+  <appSettings file=".\settings.config">
     <!-- See http://www.asp.net/identity/overview/features-api/best-practices-for-deploying-passwords-and-other-sensitive-data-to-aspnet-and-azure -->
-    <add key="Microsoft.ServiceBus.ConnectionString" value="Endpoint=sb://[your namespace].servicebus.windows.net;SharedAccessKeyName=RootManageSharedAccessKey;SharedAccessKey=[your secret]" />
   </appSettings>
   <system.web>
     <compilation debug="true" targetFramework="4.5.1" />

--- a/src/DeviceProvisioning/ProvisioningWebApi/ProvisioningWebApi/settings.template.config
+++ b/src/DeviceProvisioning/ProvisioningWebApi/ProvisioningWebApi/settings.template.config
@@ -4,6 +4,6 @@
     <add key="EventHubNamespace" value="[Event hub namespace]"/>
     <add key="EventHubName" value="[Event hub name]"/>
     <add key="EventHubSasKeyName" value="[Event hub policy name]"/>
-    <add key="StorageConnectionString" value="[Azure storage connection string]"/>
+    <add key="StorageConnectionString" value="DefaultEndpointsProtocol=https;AccountName=STORAGE-ACCOUNT-NAME;AccountKey=PRIMARY-KEY"/>
   </appSettings>
 

--- a/src/Shared/Core/Core.csproj
+++ b/src/Shared/Core/Core.csproj
@@ -94,6 +94,7 @@
     <Compile Include="DeviceProvisioningModels\DeviceEndpoint.cs" />
     <Compile Include="DeviceProvisioningModels\DeviceInfo.cs" />
     <Compile Include="DeviceProvisioningModels\DeviceMetadata.cs" />
+    <Compile Include="DeviceProvisioningModels\DeviceStateConstants.cs" />
     <Compile Include="Extensions.cs" />
     <Compile Include="Guard.cs" />
     <Compile Include="Logging\ScenarioSimulatorEventSource.cs" />

--- a/src/Shared/Core/DeviceProvisioningModels/DeviceStateConstants.cs
+++ b/src/Shared/Core/DeviceProvisioningModels/DeviceStateConstants.cs
@@ -1,0 +1,17 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Microsoft.Practices.IoTJourney.DeviceProvisioningModels
+{
+    public static class DeviceStateConstants
+    {
+        public static readonly string RegisteredState = "registered";
+        public static readonly string ProvisionedState = "provisioned";
+    }
+}


### PR DESCRIPTION
connects to #204 
connects to #205 

Add two web APIs to the device provisioning scenario:
- Register a device and set device metadata
- Get device metadata

Also changed the provisioning API so that it does not silently register a device, because that path wrote bogus metadata to the registry (and could lead to a situation where provisioning a device overwrites the real metadata). So I think it's better to have each API do one thing (register or provision).
