### PR TITLE
ScenarioSimulator to pull log level from environment variable, overriding what is in config

### DIFF
--- a/src/Simulator/ScenarioSimulator.ConsoleHost/App.config
+++ b/src/Simulator/ScenarioSimulator.ConsoleHost/App.config
@@ -10,44 +10,26 @@
   </appSettings>
 
   <runtime>
-
     <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
-
       <dependentAssembly>
-
         <assemblyIdentity name="Newtonsoft.Json" publicKeyToken="30ad4fe6b2a6aeed" culture="neutral" />
-
         <bindingRedirect oldVersion="0.0.0.0-6.0.0.0" newVersion="6.0.0.0" />
-
       </dependentAssembly>
-
       <dependentAssembly>
-
         <assemblyIdentity name="Microsoft.Data.Edm" publicKeyToken="31bf3856ad364e35" culture="neutral" />
-
         <bindingRedirect oldVersion="0.0.0.0-5.6.4.0" newVersion="5.6.4.0" />
-
       </dependentAssembly>
-
       <dependentAssembly>
-
         <assemblyIdentity name="Microsoft.Data.Services.Client" publicKeyToken="31bf3856ad364e35" culture="neutral" />
-
         <bindingRedirect oldVersion="0.0.0.0-5.6.4.0" newVersion="5.6.4.0" />
-
       </dependentAssembly>
-
       <dependentAssembly>
-
         <assemblyIdentity name="Microsoft.Data.OData" publicKeyToken="31bf3856ad364e35" culture="neutral" />
-
         <bindingRedirect oldVersion="0.0.0.0-5.6.4.0" newVersion="5.6.4.0" />
-
       </dependentAssembly>
-
     </assemblyBinding>
-
   </runtime>
+  
   <system.serviceModel>
     <extensions>
       <!-- In this extension section we are introducing all known service bus extensions. User can remove the ones they don't need. -->

--- a/src/Simulator/ScenarioSimulator.ConsoleHost/Program.cs
+++ b/src/Simulator/ScenarioSimulator.ConsoleHost/Program.cs
@@ -26,7 +26,7 @@ namespace Microsoft.Practices.IoTJourney.ScenarioSimulator.ConsoleHost
 
             var configuration = SimulatorConfiguration.GetCurrentConfiguration();
 
-            observableEventListener.EnableEvents(ScenarioSimulatorEventSource.Log, configuration.EventLevel);
+            observableEventListener.EnableEvents(ScenarioSimulatorEventSource.Log, configuration.GetLogLevel());
 
             observableEventListener.LogToConsole();
 

--- a/src/Simulator/ScenarioSimulator.Tests/ScenarioSimulator.Tests.csproj
+++ b/src/Simulator/ScenarioSimulator.Tests/ScenarioSimulator.Tests.csproj
@@ -1,5 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="..\..\packages\xunit.runner.visualstudio.2.0.1\build\net20\xunit.runner.visualstudio.props" Condition="Exists('..\..\packages\xunit.runner.visualstudio.2.0.1\build\net20\xunit.runner.visualstudio.props')" />
   <Import Project="..\..\packages\xunit.core.2.0.0\build\portable-net45+win+wpa81+wp80+monotouch+monoandroid+Xamarin.iOS\xunit.core.props" Condition="Exists('..\..\packages\xunit.core.2.0.0\build\portable-net45+win+wpa81+wp80+monotouch+monoandroid+Xamarin.iOS\xunit.core.props')" />
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <PropertyGroup>
@@ -13,7 +14,7 @@
     <TargetFrameworkVersion>v4.5.1</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\</SolutionDir>
-    <NuGetPackageImportStamp>34ecc99e</NuGetPackageImportStamp>
+    <NuGetPackageImportStamp>32ca2bb3</NuGetPackageImportStamp>
     <RestorePackages>true</RestorePackages>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
@@ -77,6 +78,12 @@
     <None Include="packages.config" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
+    <PropertyGroup>
+      <ErrorText>This project references NuGet package(s) that are missing on this computer. Enable NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
+    </PropertyGroup>
+    <Error Condition="!Exists('..\..\packages\xunit.runner.visualstudio.2.0.1\build\net20\xunit.runner.visualstudio.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\xunit.runner.visualstudio.2.0.1\build\net20\xunit.runner.visualstudio.props'))" />
+  </Target>
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.
   <Target Name="BeforeBuild">

--- a/src/Simulator/ScenarioSimulator.Tests/packages.config
+++ b/src/Simulator/ScenarioSimulator.Tests/packages.config
@@ -5,4 +5,5 @@
   <package id="xunit.assert" version="2.0.0" targetFramework="net451" />
   <package id="xunit.core" version="2.0.0" targetFramework="net451" />
   <package id="xunit.extensibility.core" version="2.0.0" targetFramework="net451" />
+  <package id="xunit.runner.visualstudio" version="2.0.1" targetFramework="net451" />
 </packages>

--- a/src/Simulator/ScenarioSimulator/SimulatorConfiguration.cs
+++ b/src/Simulator/ScenarioSimulator/SimulatorConfiguration.cs
@@ -24,7 +24,18 @@ namespace Microsoft.Practices.IoTJourney.ScenarioSimulator
 
         public TimeSpan WarmUpDuration { get; set; }
 
-        public EventLevel EventLevel { get; set; }
+        private EventLevel _eventLevel;
+        public EventLevel GetLogLevel()
+        {
+            const string Key = "IOT_LOGLEVEL";
+            object logLevel = Environment.GetEnvironmentVariable(Key);
+            if (logLevel != null)
+            {
+                _eventLevel = ConfigurationHelper.ConvertValue<EventLevel>(Key, logLevel);
+            }
+
+            return _eventLevel;
+        }
 
         public static SimulatorConfiguration GetCurrentConfiguration()
         {
@@ -38,7 +49,7 @@ namespace Microsoft.Practices.IoTJourney.ScenarioSimulator
                 EventHubPrimaryKey = ConfigurationHelper.GetConfigValue<string>("Simulator.EventHubPrimaryKey"),
                 EventHubTokenLifetimeDays = ConfigurationHelper.GetConfigValue<int>("Simulator.EventHubTokenLifetimeDays", 7),
                 WarmUpDuration = ConfigurationHelper.GetConfigValue("Simulator.WarmUpDuration", TimeSpan.FromSeconds(30)),
-                EventLevel = ConfigurationHelper.GetConfigValue<EventLevel>("Simulator.LogLevel", EventLevel.Informational)
+                _eventLevel = ConfigurationHelper.GetConfigValue<EventLevel>("Simulator.LogLevel", EventLevel.Informational)
             };
         }
 


### PR DESCRIPTION
connects to #155

Environment variable is named IOT_LOGLEVEL and accepts string values defined in System.Diagnostics.Tracing.EventLevel [Critical, Error, Informational, LogAlways, Verbose, Warning]