### PR TITLE
pointed to wrong directory - now pointing to pnp-iotjourney

### DIFF
--- a/src/LongTermStorage/Validation/HDInsight/hivequeryforcoldstorageeventprocessor.ps1
+++ b/src/LongTermStorage/Validation/HDInsight/hivequeryforcoldstorageeventprocessor.ps1
@@ -30,7 +30,7 @@ Param
 	[string] $clusterName,
 
     [string] $containerName = "blobs-processor",
-	[string] $directoryName = "fabrikam"
+	[string] $directoryName = "pnp-iotjourney"
 )
 
 Add-AzureAccount


### PR DESCRIPTION
connect to #258 

Simple issue.  We are using 'pnp-iotjourney' as our directory name.  Not
'fabrikdam'
